### PR TITLE
What if `lifted_getfield` on a tangent just called `getproperty`

### DIFF
--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -389,10 +389,7 @@ end
 lifted_getfield(x::ZeroTangent, s) = ZeroTangent()
 lifted_getfield(x::NoTangent, s) = NoTangent()
 
-function lifted_getfield(x::Tangent, s)
-    z = getfield(ChainRulesCore.backing(ChainRulesCore.canonicalize(x)), s)
-    z
-end
+lifted_getfield(x::Tangent, s) = getproperty(x, s)
 
 function lifted_getfield(x::Tangent{<:Tangent{T}}, s) where T
     bb = getfield(x.backing, 1)


### PR DESCRIPTION
Semantically these are the same.
but lets see if this works out right
