### PR TITLE
fix array indexing backward rule

### DIFF
--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -313,6 +313,7 @@ function (::∂⃖{N})(::typeof(Base.getindex), a::Array, inds...) where {N}
     getindex(a, inds...), let
         EvenOddOdd{1, c_order(N)}(
             (@Base.aggressive_constprop Δ->begin
+                Δ isa ZeroTangent && return (NoTangent(), NoTangent(), map(x->NoTangent(), inds)...)
                 BB = zero(a)
                 BB[inds...] = Δ
                 (NoTangent(), BB, map(x->NoTangent(), inds)...)

--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -313,7 +313,7 @@ function (::∂⃖{N})(::typeof(Base.getindex), a::Array, inds...) where {N}
     getindex(a, inds...), let
         EvenOddOdd{1, c_order(N)}(
             (@Base.aggressive_constprop Δ->begin
-                Δ isa ZeroTangent && return (NoTangent(), NoTangent(), map(x->NoTangent(), inds)...)
+                Δ isa AbstractZero && return (NoTangent(), Δ, map(Returns(Δ), inds)...)
                 BB = zero(a)
                 BB[inds...] = Δ
                 (NoTangent(), BB, map(x->NoTangent(), inds)...)


### PR DESCRIPTION
Fixes the following issue,

```julia
julia> using Diffractor, LinearAlgebra

julia> loss(res, z, w) = sum(res.U * Diagonal(res.S) * res.V) + sum(res.S .* w)
loss (generic function with 1 method)

julia> Diffractor.gradient(x->loss(svd(x), x[:,1], x[:,2]), dy)^C

julia> x = randn(10, 10);

julia> Diffractor.gradient(x->loss(svd(x), x[:,1], x[:,2]), x)
ERROR: ArgumentError: indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?
Stacktrace:
  [1] setindex_shape_check(::ZeroTangent, ::Int64, ::Int64)
    @ Base ./indices.jl:261
  [2] _unsafe_setindex!(::IndexLinear, ::Matrix{Float64}, ::ZeroTangent, ::Base.Slice{Base.OneTo{Int64}}, ::Int64)
    @ Base ./multidimensional.jl:903
  [3] _setindex!
    @ ./multidimensional.jl:894 [inlined]
  [4] setindex!
    @ ./abstractarray.jl:1318 [inlined]
  [5] (::Diffractor.var"#166#169"{Matrix{Float64}, Tuple{Colon, Int64}})(Δ::ZeroTangent)
    @ Diffractor ~/.julia/dev/Diffractor/src/stage1/generated.jl:317
  [6] (::Diffractor.EvenOddOdd{1, 1, Diffractor.var"#166#169"{Matrix{Float64}, Tuple{Colon, Int64}}, Diffractor.var"#168#171"{Tuple{Colon, Int64}}})(Δ::ZeroTangent)
    @ Diffractor ~/.julia/dev/Diffractor/src/stage1/generated.jl:283
  [7] ∂⃖¹₁
    @ ./none:1
  [8] (::Diffractor.∇{var"#21#22"})(args::Matrix{Float64})
    @ Diffractor ~/.julia/dev/Diffractor/src/interface.jl:122
  [9] Diffractor.∇(::Function, ::Matrix{Float64})
    @ Diffractor ~/.julia/dev/Diffractor/src/interface.jl:128
 [10] top-level scope
    @ REPL[27]:1
```

Where should I put the test?