### PR TITLE
WIP: Refactor forward mode data structures

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -64,7 +64,7 @@ dx(x) = error("Cotangent space not defined for `$(typeof(x))`. Try a real-valued
 For `x` in a one dimensional manifold, map x to the trivial, unital, 1st order
 tangent bundle. It should hold that `∀x ⟨∂x(x), dx(x)⟩ = 1`
 """
-∂x(x::Real) = TangentBundle{1}(x, (one(x),))
+∂x(x::Real) = ExplicitTangentBundle{1}(x, (one(x),))
 ∂x(x) = error("Tangent space not defined for `$(typeof(x)).")
 
 struct ∂xⁿ{N}; end
@@ -177,7 +177,7 @@ raise_pd(f::PrimeDerivativeFwd{N,T}) where {N,T} = PrimeDerivativeFwd{plus1(N),T
 
 function (f::PrimeDerivativeFwd{1})(x)
     z = ∂☆¹(ZeroBundle{1}(getfield(f, :f)), ∂x(x))
-    z.partials[1]
+    z.tangent.partials[1]
 end
 
 function (f::PrimeDerivativeFwd{N})(x) where N

--- a/src/jet.jl
+++ b/src/jet.jl
@@ -187,9 +187,9 @@ function (∂⃖ₙ::∂⃖{N})(::typeof(map), f, a::Array) where {N}
         ∂f = ∂☆{N}()(ZeroBundle{N}(f),
                      TaylorBundle{N}(x,
                        (one(x), (zero(x) for i = 1:(N-1))...,)))
-        @assert isa(∂f, TaylorBundle) || isa(∂f, TangentBundle{1})
+        @assert isa(∂f, TaylorBundle) || isa(∂f, ExplicitTangentBundle{1})
         Jet{typeof(x), N}(x, ∂f.primal,
-            isa(∂f, TangentBundle) ? ∂f.partials : ∂f.coeffs)
+            isa(∂f, ExplicitTangentBundle) ? ∂f.tangent.partials : ∂f.tangent.coeffs)
     end
     ∂⃖ₙ(mapev, js, a)
 end
@@ -243,18 +243,18 @@ end
     O = min(M,N)
     quote
         domain_check(j, x.primal)
-        coeffs = x.coeffs
+        coeffs = x.tangent.coeffs
         TaylorBundle{$O}(j[0],
             ($((:(jet_taylor_ev(Val{$i}(), coeffs, j)) for i = 1:O)...),))
     end
 end
 
-function (j::Jet{T, 1} where T)(x::TangentBundle{1})
+function (j::Jet{T, 1} where T)(x::ExplicitTangentBundle{1})
     domain_check(j, x.primal)
-    coeffs = x.partials
-    TangentBundle{1}(j[0], (jet_taylor_ev(Val{1}(), coeffs, j),))
+    coeffs = x.tangent.partials
+    ExplicitTangentBundle{1}(j[0], (jet_taylor_ev(Val{1}(), coeffs, j),))
 end
 
-function (j::Jet{T, N} where T)(x::TangentBundle{N, M}) where {N, M}
+function (j::Jet{T, N} where T)(x::ExplicitTangentBundle{N, M}) where {N, M}
     error("TODO")
 end

--- a/src/stage1/mixed.jl
+++ b/src/stage1/mixed.jl
@@ -95,9 +95,9 @@ function (∂⃖ₙ::∂⃖{N})(∂☆ₘ::∂☆{M}, ::ZeroBundle{M, typeof(map
         ∂f = ∂☆{N+M}()(ZeroBundle{N+M}(primal(f)),
                      TaylorBundle{N+M}(x,
                        (one(x), (zero(x) for i = 1:(N+M-1))...,)))
-        @assert isa(∂f, TaylorBundle) || isa(∂f, TangentBundle{1})
+        @assert isa(∂f, TaylorBundle) || isa(∂f, ExplicitTangentBundle{1})
         Jet{typeof(x), N+M}(x, ∂f.primal,
-            isa(∂f, TangentBundle) ? ∂f.partials : ∂f.coeffs)
+            isa(∂f, ExplicitTangentBundle) ? ∂f.tangent.partials : ∂f.tangent.coeffs)
     end
     ∂⃖ₙ(mapev_unbundled, ∂☆ₘ, js, a)
 end


### PR DESCRIPTION
To allow chunking like ForwardDiff.

I think this works on the Diffractor side at this point, but there's a question about the interfaces with ChainRules. In particular, to what extent do we want to want/need ChainRules to be chunking-aware. Previously ChainRules did allow tuples/arrays in its forwards rules, but we removed that support in preparation for Diffractor, because having broadcasting in the rules makes them a lot more expensive at higher orders. I think our options here are:

1. Put the broadcasting back into ChainRules
2. Have some sort of `ImplicitBroadcast` type that wraps our values and implicitly broadcasts them as appropriate (so the rules look "scalar", but actually work with chunked values).
3. Option 2 + some compiler support to implement `ImplicitBroadcast` even if the type annotations are too restrictive.
4. Change the `frule` interface to also use closures like rrule, with the semantics being that for chunked evaluation, you broadcast the pushforward over the tangent vectors.

My current thinking is that either option 3 or 4 is perhaps attractive, but I'd like @oxinabox @mcabbott and @simeonschaub to weigh in with their opinions.