### PR TITLE
bump compact bound to Julia 1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Combinatorics = "1"
 StaticArrays = "1"
 StatsBase = "0.33"
 StructArrays = "0.6"
-julia = "1.7"
+julia = "1.8"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"


### PR DESCRIPTION
This package is using `Base.@constprop` in many places, which does not exist in Julia 1.7, rather it'll be a 1.8 feature if I understand correctly. 