### PR TITLE
add `dx` methods

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -53,6 +53,8 @@ However, users may provide additional overloads for custom representations of
 one dimensional Riemannian manifolds.
 """
 dx(x::Real) = one(x)
+dx(::NoTangent) = NoTangent()
+dx(::ZeroTangent) = ZeroTangent()
 dx(x::Complex) = error("Tried to take the gradient of a complex-valued function.")
 dx(x) = error("Cotangent space not defined for `$(typeof(x))`. Try a real-valued function.")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,6 +184,8 @@ end
 @test bwd(x->f_crit_edge(true, true, false, x))(1.0) == 2.0
 @test bwd(x->f_crit_edge(false, true, true, x))(1.0) == 12.0
 @test bwd(x->f_crit_edge(false, false, true, x))(1.0) == 4.0
+@test bwd(bwd(x->5)))(1.0) == ZeroTangent()
+@test fwd(fwd(x->5)))(1.0) == ZeroTangent()
 
 # Issue #27 - Mixup in lifting of getfield
 let var"'" = bwd

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,8 +184,8 @@ end
 @test bwd(x->f_crit_edge(true, true, false, x))(1.0) == 2.0
 @test bwd(x->f_crit_edge(false, true, true, x))(1.0) == 12.0
 @test bwd(x->f_crit_edge(false, false, true, x))(1.0) == 4.0
-@test bwd(bwd(x->5)))(1.0) == ZeroTangent()
-@test fwd(fwd(x->5)))(1.0) == ZeroTangent()
+@test bwd(bwd(x->5))(1.0) == ZeroTangent()
+@test fwd(fwd(x->5))(1.0) == ZeroTangent()
 
 # Issue #27 - Mixup in lifting of getfield
 let var"'" = bwd


### PR DESCRIPTION
Before
```
const bwd = Diffractor.PrimeDerivativeBack
bwd(bwd(x->5))
```
failed.