### PR TITLE
Add `DiffractorRuleConfig` to extra `rrule`s

### DIFF
--- a/src/stage1/broadcast.jl
+++ b/src/stage1/broadcast.jl
@@ -62,12 +62,12 @@ unbroadcast(x::AbstractArray, x̄::Nothing) = NoTangent()
 
 const Numeric = Union{Number, AbstractArray{<:Number, N} where N}
 
-function ChainRulesCore.rrule(::typeof(broadcasted), ::typeof(+), xs::Numeric...)
+function ChainRulesCore.rrule(::DiffractorRuleConfig, ::typeof(broadcasted), ::typeof(+), xs::Numeric...)
     broadcast(+, xs...), ȳ -> (NoTangent(), NoTangent(), map(x -> unbroadcast(x, unthunk(ȳ)), xs)...)
 end
 
-ChainRulesCore.rrule(::typeof(broadcasted), ::typeof(-), x::Numeric, y::Numeric) = x .- y,
+ChainRulesCore.rrule(::DiffractorRuleConfig, ::typeof(broadcasted), ::typeof(-), x::Numeric, y::Numeric) = x .- y,
   Δ -> let Δ=unthunk(Δ); (NoTangent(), NoTangent(), unbroadcast(x, Δ), -unbroadcast(y, Δ)); end
 
-ChainRulesCore.rrule(::typeof(broadcasted), ::typeof(*), x::Numeric, y::Numeric) = x.*y,
+ChainRulesCore.rrule(::DiffractorRuleConfig, ::typeof(broadcasted), ::typeof(*), x::Numeric, y::Numeric) = x.*y,
   z̄ -> let z̄=unthunk(z̄); (NoTangent(), NoTangent(), unbroadcast(x, z̄ .* conj.(y)), unbroadcast(y, z̄ .* conj.(x))); end


### PR DESCRIPTION
This should mean fewer pirate surprises if trying this out alongside Zygote/Yota.

Some of these have I think been moved to CR, so can be deleted, but not this PR. Before this PR, the following methods give warnings:
```
julia> using Diffractor
[ Info: Precompiling Diffractor [9f5e2b26-1114-432f-b630-d3fe2085c51c]
WARNING: Method definition rrule(typeof(Core.apply_type), Any, Any...) in module ChainRules at /Users/me/.julia/dev/ChainRules/src/rulesets/Core/core.jl:10 overwritten in module Diffractor at /Users/me/.julia/packages/Diffractor/shAfL/src/extra_rules.jl:140.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition frule(Any, typeof(Base.getindex), AbstractArray{T, N} where N where T, Any...) in module ChainRules at /Users/me/.julia/dev/ChainRules/src/rulesets/Base/indexing.jl:60 overwritten in module Diffractor at /Users/me/.julia/packages/Diffractor/shAfL/src/extra_rules.jl:190.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition rrule(Type{var"#s309"} where var"#s309"<:(Array{T, N} where N where T), UndefInitializer, Any...) in module ChainRules at /Users/me/.julia/dev/ChainRules/src/rulesets/Base/array.jl:5 overwritten in module Diffractor at /Users/me/.julia/packages/Diffractor/shAfL/src/extra_rules.jl:209.
  ** incremental compilation may be fatally broken for this module **

WARNING: using StatsBase.trim in module Diffractor conflicts with an existing identifier.
```

(Test failures should be fixed by #79)