### PR TITLE
Support getindex on non-numeric arrays

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,3 +218,6 @@ z45, delta45 = frule_via_ad(DiffractorRuleConfig(), (0,1), x -> log(exp(x)), 2)
 
 # Higher order control flow not yet supported (https://github.com/JuliaDiff/Diffractor.jl/issues/24)
 #include("pinn.jl")
+
+# PR #82 - getindex on non-numeric arrays
+@test Diffractor.gradient(ls -> ls[1](1.), [Base.Fix1(*, 1.)])[1][1] isa Tangent{<:Base.Fix1}


### PR DESCRIPTION
This came up while trying to run Flux models with `Chain{<:Vector}`.