### PR TITLE
Hookup demand-driven forward mode to the Diffractor runtime

### DIFF
--- a/src/higher_fwd_rules.jl
+++ b/src/higher_fwd_rules.jl
@@ -28,6 +28,23 @@ for f in (sin, cos, exp)
     end
 end
 
+# TODO: It's a bit embarassing that we need to write these out, but currently the
+# compiler is not strong enough to automatically lift the frule. Let's hope we
+# can delete these in the near future.
+function (∂☆ₙ::∂☆{N})(fb::ZeroBundle{N, typeof(+)}, a::TaylorBundle{N}, b::TaylorBundle{N}) where {N}
+    TaylorBundle{N}(primal(a) + primal(b),
+        map(+, a.tangent.coeffs, b.tangent.coeffs))
+end
+
+function (∂☆ₙ::∂☆{N})(fb::ZeroBundle{N, typeof(+)}, a::TaylorBundle{N}, b::ZeroBundle{N}) where {N}
+    TaylorBundle{N}(primal(a) + primal(b), a.tangent.coeffs)
+end
+
+function (∂☆ₙ::∂☆{N})(fb::ZeroBundle{N, typeof(-)}, a::TaylorBundle{N}, b::TaylorBundle{N}) where {N}
+    TaylorBundle{N}(primal(a) - primal(b),
+        map(-, a.tangent.coeffs, b.tangent.coeffs))
+end
+
 function (::Diffractor.∂☆new{N})(B::ATB{N, Type{T}}, args::ATB{N}...) where {N, T<:SArray}
     error("Should have intercepted the constructor")
 end

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -205,13 +205,15 @@ struct FwdIterate{N, T<:AbstractTangentBundle{N}}
 end
 function (f::FwdIterate)(arg::ATB{N}) where {N}
     r = ∂☆{N}()(f.f, arg)
-    primal(r) === nothing && return nothing
+    # `primal(r) === nothing` would work, but doesn't create `Conditional` in inference
+    isa(r, ATB{N, Nothing}) && return nothing
     (∂☆{N}()(ZeroBundle{N}(getindex), r, ZeroBundle{N}(1)),
      primal(∂☆{N}()(ZeroBundle{N}(getindex), r, ZeroBundle{N}(2))))
 end
-function (f::FwdIterate)(arg::ATB{N}, st) where {N}
+@Base.constprop :aggressive function (f::FwdIterate)(arg::ATB{N}, st) where {N}
     r = ∂☆{N}()(f.f, arg, ZeroBundle{N}(st))
-    primal(r) === nothing && return nothing
+    # `primal(r) === nothing` would work, but doesn't create `Conditional` in inference
+    isa(r, ATB{N, Nothing}) && return nothing
     (∂☆{N}()(ZeroBundle{N}(getindex), r, ZeroBundle{N}(1)),
      primal(∂☆{N}()(ZeroBundle{N}(getindex), r, ZeroBundle{N}(2))))
 end

--- a/src/stage2/forward.jl
+++ b/src/stage2/forward.jl
@@ -2,7 +2,7 @@ using .CC: compact!
 
 # Engineering entry point for the 2nd-order forward AD functionality. This is
 # unlikely to be the actual interface. For now, it is used for testing.
-function dontuse_nth_order_forward_stage2(tt::Type)
+function dontuse_nth_order_forward_stage2(tt::Type, order::Int=1)
     interp = ADInterpreter(; forward=true, backward=false)
     match = Base._which(tt)
     frame = Core.Compiler.typeinf_frame(interp, match.method, match.spec_types, match.sparams, #=run_optimizer=#true)
@@ -10,26 +10,44 @@ function dontuse_nth_order_forward_stage2(tt::Type)
     ir = copy((interp.opt[0][frame.linfo].inferred).ir::IRCode)
 
     # Find all Return Nodes
-    vals = SSAValue[]
+    vals = Pair{SSAValue, Int}[]
     for i = 1:length(ir.stmts)
         if isa(ir[SSAValue(i)][:inst], ReturnNode)
-            push!(vals, SSAValue(i))
+            push!(vals, SSAValue(i)=>order)
         end
     end
 
-    function custom_diff!(ir, ssa, stmt, recurse)
+    function visit_custom!(ir::IRCode, @nospecialize(stmt), order, recurse)
         if isa(stmt, ReturnNode)
-            r = recurse(stmt.val)
-            ir[ssa][:inst] = ReturnNode(r)
-            return ssa
+            recurse(stmt.val)
+            return true
         elseif isa(stmt, Argument)
-            return 1.0
+            return true
+        else
+            return false
         end
-        return nothing
     end
+
+    function transform!(ir::IRCode, ssa::SSAValue, _)
+        inst = ir[ssa]
+        stmt = inst[:inst]
+        if isa(stmt, ReturnNode)
+            nr = insert_node!(ir, ssa, NewInstruction(Expr(:call, getindex, stmt.val, TaylorTangentIndex(order)), Any))
+            inst[:inst] = ReturnNode(nr)
+        else
+            error()
+        end
+    end
+
+    function transform!(ir::IRCode, arg::Argument, _)
+        return insert_node!(ir, SSAValue(1), NewInstruction(Expr(:call, ∂xⁿ{order}(), arg), typeof(∂xⁿ{order}()(1.0))))
+    end
+
 
     irsv = CC.IRInterpretationState(interp, ir, frame.linfo, CC.get_world_counter(interp), ir.argtypes[1:frame.linfo.def.nargs])
-    forward_diff!(ir, interp, irsv, vals; custom_diff!)
+    ir = forward_diff!(ir, interp, frame.linfo, CC.get_world_counter(interp), vals; visit_custom!, transform!)
+
+    display(ir)
 
     ir = compact!(ir)
     return OpaqueClosure(ir)

--- a/src/stage2/lattice.jl
+++ b/src/stage2/lattice.jl
@@ -76,6 +76,10 @@ function Base.show(io::IO, info::FRuleCallInfo)
     print(io, "FRuleCallInfo(", typeof(info.info), ", ", typeof(info.frule_call.info), ")")
 end
 
+function Cthulhu.process_info(interp::AbstractInterpreter, info::FRuleCallInfo, argtypes::Cthulhu.ArgTypes, @nospecialize(rt), optimize::Bool)
+    return Cthulhu.process_info(interp, info.info, argtypes, rt, optimize)
+end
+
 
 # Helpers
 tuple_type_fields(rt) = isa(rt, PartialStruct) ? rt.fields : widenconst(rt).parameters

--- a/test/stage2_fwd.jl
+++ b/test/stage2_fwd.jl
@@ -1,7 +1,22 @@
 module stage2_fwd
-    using Diffractor, Test
+    using Diffractor, Test, ChainRulesCore
     mysin(x) = sin(x)
     let sin′ = Diffractor.dontuse_nth_order_forward_stage2(Tuple{typeof(mysin), Float64})
         @test sin′(1.0) == cos(1.0)
+    end
+    let sin′′ = Diffractor.dontuse_nth_order_forward_stage2(Tuple{typeof(mysin), Float64}, 2)
+        @test isa(sin′′, Core.OpaqueClosure{Tuple{Float64}, Float64})
+        @test sin′′(1.0) == -sin(1.0)
+    end
+
+    myminus(a, b) = a - b
+    @ChainRulesCore.scalar_rule myminus(x, y) (true, -1)
+
+    self_minus(a) = myminus(a, a)
+    let self_minus′′ = Diffractor.dontuse_nth_order_forward_stage2(Tuple{typeof(self_minus), Float64}, 2)
+        # TODO: The IR for this currently contains Union{Diffractor.TangentBundle{2, Float64, Diffractor.ExplicitTangent{Tuple{Float64, Float64, Float64}}}, Diffractor.TangentBundle{2, Float64, Diffractor.TaylorTangent{Tuple{Float64, Float64}}}}
+        # We should have Diffractor be able to prove uniformity
+        @test isa(self_minus′′, Core.OpaqueClosure{Tuple{Float64}, Float64})
+        @test sin′′(1.0) == -sin(1.0)
     end
 end


### PR DESCRIPTION
Tests currently depend on https://github.com/JuliaLang/julia/pull/48045 and https://github.com/JuliaLang/julia/pull/48059, so we should either get those merged first, or mark them here as broken.