### PR TITLE
forward_demand: Implement bundle truncation

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -177,7 +177,7 @@ raise_pd(f::PrimeDerivativeFwd{N,T}) where {N,T} = PrimeDerivativeFwd{plus1(N),T
 
 function (f::PrimeDerivativeFwd{1})(x)
     z = ∂☆¹(ZeroBundle{1}(getfield(f, :f)), ∂x(x))
-    z.tangent.partials[1]
+    z[TaylorTangentIndex(1)]
 end
 
 function (f::PrimeDerivativeFwd{N})(x) where N

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -106,7 +106,7 @@ end
 struct ∂☆internal{N}; end
 struct ∂☆shuffle{N}; end
 
-shuffle_base(r) = ExplicitTangentBundle{1}(r[1], (r[2],))
+shuffle_base(r) = TaylorBundle{1}(r[1], (r[2],))
 
 function (::∂☆internal{1})(args::AbstractTangentBundle{1}...)
     r = my_frule(args...)

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -211,6 +211,13 @@ function TaylorBundle{N}(primal, coeffs) where {N}
     TaylorBundle{N, Core.Typeof(primal)}(primal, coeffs)
 end
 
+function Base.show(io::IO, x::TaylorBundle{1})
+    print(io, x.primal)
+    print(io, " + ")
+    x = x.tangent
+    print(io, x.coeffs[1], " ∂₁")
+end
+
 Base.getindex(tb::TaylorBundle, tti::TaylorTangentIndex) = tb.tangent.coeffs[tti.i]
 function Base.getindex(tb::TaylorBundle, tti::CanonicalTangentIndex)
     tb.tangent.coeffs[count_ones(tti.i)]


### PR DESCRIPTION
Also make the canonical 1-bundle use the TaylorBundle type. The types are isomorphic, but since `∂xⁿ{1}()` returns a TaylorBundle, this helps type stability.