### PR TITLE
add handling for lshr_int

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -267,6 +267,8 @@ function (this::∂☆{N})(f::ZeroBundle{N, Core.IntrinsicFunction}, args::ATB{N
     ff = primal(f)
     if ff === Base.not_int
         DNEBundle{N}(ff(map(primal, args)...))
+    elseif ff === Base.lshr_int
+        ZeroBundle{N}(ff(map(primal, args)...))
     else
         error("Missing rule for intrinsic function $ff")
     end


### PR DESCRIPTION
I'm not sure if this is needed or correct but the bsim_group tran tests errors here (after warning about incidence though, so maybe this would have just been inlined)