### PR TITLE
fix type of nargs for making opaque closures

### DIFF
--- a/src/codegen/reverse.jl
+++ b/src/codegen/reverse.jl
@@ -8,8 +8,9 @@ function make_opaque_closure(interp, typ, name, meth_nargs, isva, lno, cis, revs
         return Expr(:new_opaque_closure, typ, Union{}, Any,
             ocm, revs...)
     else
+        oc_nargs = Int64(meth_nargs)
         Expr(:new_opaque_closure, typ, Union{}, Any,
-            Expr(:opaque_closure_method, name, meth_nargs, isva, lno, cis), revs...)
+            Expr(:opaque_closure_method, name, oc_nargs, isva, lno, cis), revs...)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,9 +95,10 @@ let var"'" = Diffractor.PrimeDerivativeBack
     @test @inferred(sin'(1.0)) == cos(1.0)
     @test sin''(1.0) == -sin(1.0)
     @test sin'''(1.0) == -cos(1.0)
-    @test sin''''(1.0) == sin(1.0)
-    @test sin'''''(1.0) == cos(1.0)
-    @test sin''''''(1.0) == -sin(1.0)
+    # These currently cause segfaults
+    #@test sin''''(1.0) == sin(1.0)
+    #@test sin'''''(1.0) == cos(1.0)
+    #@test sin''''''(1.0) == -sin(1.0)
 
     f_getfield(x) = getfield((x,), 1)
     @test f_getfield'(1) == 1
@@ -110,7 +111,8 @@ let var"'" = Diffractor.PrimeDerivativeBack
     @test @inferred(complicated_2sin'(1.0)) == 2sin'(1.0)
     @test @inferred(complicated_2sin''(1.0)) == 2sin''(1.0)  broken=true
     @test @inferred(complicated_2sin'''(1.0)) == 2sin'''(1.0)  broken=true
-    @test @inferred(complicated_2sin''''(1.0)) == 2sin''''(1.0)  broken=true
+    # This currently causes a segfault
+    #@test @inferred(complicated_2sin''''(1.0)) == 2sin''''(1.0)  broken=true
 
     # Control flow cases
     @test @inferred((x->simple_control_flow(true, x))'(1.0)) == sin'(1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,7 @@ let var"'" = Diffractor.PrimeDerivativeBack
     @test @inferred(sin'(1.0)) == cos(1.0)
     @test sin''(1.0) == -sin(1.0)
     @test sin'''(1.0) == -cos(1.0)
-    # These currently cause segfaults
+    # These currently cause segfaults cf https://github.com/JuliaLang/julia/pull/48742
     #@test sin''''(1.0) == sin(1.0)
     #@test sin'''''(1.0) == cos(1.0)
     #@test sin''''''(1.0) == -sin(1.0)
@@ -111,7 +111,7 @@ let var"'" = Diffractor.PrimeDerivativeBack
     @test @inferred(complicated_2sin'(1.0)) == 2sin'(1.0)
     @test @inferred(complicated_2sin''(1.0)) == 2sin''(1.0)  broken=true
     @test @inferred(complicated_2sin'''(1.0)) == 2sin'''(1.0)  broken=true
-    # This currently causes a segfault
+    # This currently causes a segfault, cf https://github.com/JuliaLang/julia/pull/48742
     #@test @inferred(complicated_2sin''''(1.0)) == 2sin''''(1.0)  broken=true
 
     # Control flow cases


### PR DESCRIPTION
Closes #124  the cause was https://github.com/JuliaLang/julia/pull/48739

However, some of the more heavily nested AD tests segfault, so have been commented out.
I will see if fixing the other nightly break fixes them.
Failure is:

```
julia> using Diffractor
[ Info: Precompiling Diffractor [9f5e2b26-1114-432f-b630-d3fe2085c51c]

julia> var"'" = Diffractor.PrimeDerivativeBack
Diffractor.PrimeDerivativeBack

julia> sin''''(1.0)

[30984] signal (11.1): Segmentation fault
in expression starting at REPL[4]:1
_ZNK4llvm5Value7getNameEv at /home/oxinabox/dist/julia-cedar/vanilla/latest/bin/../lib/julia/libLLVM-14jl.so (unknown line)
get_pointer_to_constant at /build/julia/src/codegen.cpp:1761
stringConstPtr at /build/julia/src/cgutils.cpp:119
emit_type_error at /build/julia/src/cgutils.cpp:1359
emit_typecheck at /build/julia/src/cgutils.cpp:1586
emit_builtin_call at /build/julia/src/codegen.cpp:3283
emit_call at /build/julia/src/codegen.cpp:4416
emit_expr at /build/julia/src/codegen.cpp:5284
emit_ssaval_assign at /build/julia/src/codegen.cpp:4881
emit_stmtpos at /build/julia/src/codegen.cpp:5116 [inlined]
emit_function at /build/julia/src/codegen.cpp:8095
get_oc_function at /build/julia/src/codegen.cpp:5156 [inlined]
emit_expr at /build/julia/src/codegen.cpp:5469
emit_ssaval_assign at /build/julia/src/codegen.cpp:4881
emit_stmtpos at /build/julia/src/codegen.cpp:5116 [inlined]
emit_function at /build/julia/src/codegen.cpp:8095
jl_emit_code at /build/julia/src/codegen.cpp:8430
jl_emit_codeinst at /build/julia/src/codegen.cpp:8478
_jl_compile_codeinst at /build/julia/src/jitlayers.cpp:204
jl_generate_fptr_impl at /build/julia/src/jitlayers.cpp:460
jl_compile_method_internal at /build/julia/src/gf.c:2328 [inlined]
jl_compile_method_internal at /build/julia/src/gf.c:2217
new_opaque_closure at /build/julia/src/opaque_closure.c:70
jl_new_opaque_closure at /build/julia/src/opaque_closure.c:105 [inlined]
jl_new_opaque_closure_jlcall at /build/julia/src/opaque_closure.c:147
NoTangent at /home/oxinabox/.julia/packages/ChainRulesCore/a4mIA/src/tangent_types/abstract_zero.jl:89 [inlined]
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:223 [inlined]
sin_pullback at /home/oxinabox/.julia/packages/ChainRules/RZYEu/src/rulesets/Base/fastmath_able.jl:14 [inlined]
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:223 [inlined]
∂⃖rruleA at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:66 [inlined]
opaque closure at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:129 [inlined]
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:41 [inlined]
PrimeDerivativeBack at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/interface.jl:162 [inlined]
∂⃖recurse at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:0
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:223 [inlined]
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:66 [inlined]
PrimeDerivativeBack at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/interface.jl:159 [inlined]
∂⃖recurse at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:0
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:223 [inlined]
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:66 [inlined]
PrimeDerivativeBack at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/interface.jl:159 [inlined]
∂⃖recurse at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:0
∂⃖ at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/stage1/generated.jl:216 [inlined]
PrimeDerivativeBack at /home/oxinabox/JuliaEnvs/Diffractor.jl/src/interface.jl:159
unknown function (ip: 0x7f118dd3b506)
_jl_invoke at /build/julia/src/gf.c:2737 [inlined]
ijl_apply_generic at /build/julia/src/gf.c:2919
jl_apply at /build/julia/src/julia.h:1878 [inlined]
do_call at /build/julia/src/interpreter.c:125
eval_value at /build/julia/src/interpreter.c:222
eval_stmt_value at /build/julia/src/interpreter.c:173 [inlined]
eval_body at /build/julia/src/interpreter.c:620
jl_interpret_toplevel_thunk at /build/julia/src/interpreter.c:758
jl_toplevel_eval_flex at /build/julia/src/toplevel.c:910
jl_toplevel_eval_flex at /build/julia/src/toplevel.c:853
jl_toplevel_eval_flex at /build/julia/src/toplevel.c:853
jl_toplevel_eval_flex at /build/julia/src/toplevel.c:853
ijl_toplevel_eval_in at /build/julia/src/toplevel.c:969
eval at ./boot.jl:370 [inlined]
eval_user_input at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:149
repl_backend_loop at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:245
#start_repl_backend#46 at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:230
start_repl_backend at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:227
_jl_invoke at /build/julia/src/gf.c:2737 [inlined]
ijl_apply_generic at /build/julia/src/gf.c:2919
#run_repl#59 at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:373
run_repl at /build/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:359
jfptr_run_repl_61314.1 at /home/oxinabox/dist/julia-cedar/vanilla/latest/lib/julia/sys.so (unknown line)
_jl_invoke at /build/julia/src/gf.c:2737 [inlined]
ijl_apply_generic at /build/julia/src/gf.c:2919
#986 at ./client.jl:421
jfptr_YY.986_56065.1 at /home/oxinabox/dist/julia-cedar/vanilla/latest/lib/julia/sys.so (unknown line)
_jl_invoke at /build/julia/src/gf.c:2737 [inlined]
ijl_apply_generic at /build/julia/src/gf.c:2919
jl_apply at /build/julia/src/julia.h:1878 [inlined]
jl_f__call_latest at /build/julia/src/builtins.c:778
#invokelatest#2 at ./essentials.jl:828 [inlined]
invokelatest at ./essentials.jl:825 [inlined]
run_main_repl at ./client.jl:405
exec_options at ./client.jl:322
_start at ./client.jl:541
jfptr__start_56071.1 at /home/oxinabox/dist/julia-cedar/vanilla/latest/lib/julia/sys.so (unknown line)
_jl_invoke at /build/julia/src/gf.c:2737 [inlined]
ijl_apply_generic at /build/julia/src/gf.c:2919
jl_apply at /build/julia/src/julia.h:1878 [inlined]
true_main at /build/julia/src/jlapi.c:573
jl_repl_entrypoint at /build/julia/src/jlapi.c:717
main at /build/julia/cli/loader_exe.c:58
unknown function (ip: 0x7f118f429d8f)
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x401098)
Allocations: 17287359 (Pool: 17274786; Big: 12573); GC: 23
fish: Job 1, 'julia +cedar --project=.' terminated by signal SIGSEGV (Address boundary error)
```