### PR TITLE
follow up the `@generated` function update

### DIFF
--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -6,6 +6,12 @@ struct ∂⃖recurse{N}; end
 
 include("recurse.jl")
 
+function generate_lambda_ex(world::UInt, source::LineNumberNode,
+                            args::Core.SimpleVector, sparams::Core.SimpleVector, body::Expr)
+    stub = Core.GeneratedFunctionStub(identity, args, sparams)
+    return stub(world, source, body)
+end
+
 function perform_optic_transform(world::UInt, source::LineNumberNode,
                                  @nospecialize(ff::Type{∂⃖recurse{N}}), @nospecialize(args)) where {N}
     @assert N >= 1
@@ -15,8 +21,8 @@ function perform_optic_transform(world::UInt, source::LineNumberNode,
     mthds = Base._methods_by_ftype(sig, -1, world)
     if mthds === nothing || length(mthds) != 1
         # Core.println("[perform_optic_transform] ", sig, " => ", mthds)
-        stub = Core.GeneratedFunctionStub(identity, Core.svec(:ff, :args), Core.svec())
-        return stub(world, source, :(throw(MethodError(ff, args))))
+        return generate_lambda_ex(world, source,
+            Core.svec(:ff, :args), Core.svec(), :(throw(MethodError(ff, args))))
     end
     match = only(mthds)::Core.MethodMatch
 

--- a/src/stage1/recurse_fwd.jl
+++ b/src/stage1/recurse_fwd.jl
@@ -31,7 +31,8 @@ end
 function perform_fwd_transform(world::UInt, source::LineNumberNode,
                                @nospecialize(ff::Type{∂☆recurse{N}}), @nospecialize(args)) where {N}
     if all(x->x <: ZeroBundle, args)
-        return :(∂☆passthrough(args))
+        return generate_lambda_ex(world, source,
+            Core.svec(:ff, :args), Core.svec(), :(∂☆passthrough(args)))
     end
 
     # Check if we have an rrule for this function
@@ -39,8 +40,8 @@ function perform_fwd_transform(world::UInt, source::LineNumberNode,
     mthds = Base._methods_by_ftype(sig, -1, world)
     if mthds === nothing || length(mthds) != 1
         # Core.println("[perform_fwd_transform] ", sig, " => ", mthds)
-        stub = Core.GeneratedFunctionStub(identity, Core.svec(:ff, :args), Core.svec())
-        return stub(world, source, :(∂☆nomethd(args)))
+        return generate_lambda_ex(world, source,
+            Core.svec(:ff, :args), Core.svec(), :(∂☆nomethd(args)))
     end
     match = only(mthds)::Core.MethodMatch
 


### PR DESCRIPTION
We need to make sure to generate `:lambda` expression for fallback cases, otherwise we will end up with the following code generation error: <https://github.com/JuliaLang/julia/blob/38d24e574caab20529a61a6f7444c9e473724ccc/src/method.c#L603>

And now Diffractor is fully adjusted to the latest nightly build 🎉 