### PR TITLE
Compact show for ZeroBundle etc

### DIFF
--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -259,6 +259,18 @@ wrapper_name(::Type{<:ZeroBundle}) = "ZeroBundle"
 wrapper_name(::Type{<:DNEBundle}) = "DNEBundle"
 wrapper_name(::Type{<:AbstractZeroBundle}) = "AbstractZeroBundle"
 
+function Base.show(io::IO, T::Type{<:AbstractZeroBundle{N, B}}) where {N,B}
+    print(io, wrapper_name(T))
+    print(io, "{$N, ")
+    show(io, B)
+    print(io, "}")
+end
+
+function Base.show(io::IO, T::Type{<:AbstractZeroBundle{N}}) where {N}
+    print(io, wrapper_name(T))
+    print(io, "{$N}")
+end
+
 function Base.show(io::IO, t::AbstractZeroBundle{N}) where N
     print(io, wrapper_name(typeof(t)))
     print(io, "{$N}(")

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -250,8 +250,22 @@ UniformBundle{N}(primal, partial::U) where {N,U} = _TangentBundle(Val{N}(), prim
 UniformBundle{N, <:Any, U}(primal, partial::U) where {N, U} = _TangentBundle(Val{N}(), primal, UniformTangent{U}(U.instance))
 UniformBundle{N, <:Any, U}(primal) where {N, U} = _TangentBundle(Val{N}(), primal, UniformTangent{U}(U.instance))
 
+
 const ZeroBundle{N, B} = UniformBundle{N, B, ZeroTangent}
 const DNEBundle{N, B} = UniformBundle{N, B, NoTangent}
+const AbstractZeroBundle{N, B} = UniformBundle{N, B, <:AbstractZero}
+
+wrapper_name(::Type{<:ZeroBundle}) = "ZeroBundle"
+wrapper_name(::Type{<:DNEBundle}) = "DNEBundle"
+wrapper_name(::Type{<:AbstractZeroBundle}) = "AbstractZeroBundle"
+
+function Base.show(io::IO, t::AbstractZeroBundle{N}) where N
+    print(io, wrapper_name(typeof(t)))
+    print(io, "{$N}(")
+    show(io, t.primal)
+    print(io, ")")
+end
+
 
 Base.getindex(u::UniformBundle, ::TaylorTangentIndex) = u.tangent.val
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,9 @@ const bwd = Diffractor.PrimeDerivativeBack
 
 @testset verbose=true "Diffractor.jl" begin  # overall testset, ensures all tests run
 
-include("stage2_fwd.jl")
+@testset "$file" for file in ("stage2_fwd.jl", "tangent.jl")
+    include(file)
+end
 
 # Unit tests
 function tup2(f)

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -18,7 +18,7 @@ using Test
         @test repr(ZeroBundle{1}) == "ZeroBundle{1}"
         @test repr(ZeroBundle{1, Float64}) == "ZeroBundle{1, Float64}"
 
-        @test repr(typeof(DNEBundle{1}(getfield))) == DNEBundle{1, typeof(getfield)}
+        @test repr(typeof(DNEBundle{1}(getfield))) == "DNEBundle{1, typeof(getfield)}"
     end
 end
 

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -14,6 +14,11 @@ using Test
     @testset "Display" begin
         @test repr(ZeroBundle{1}(2.0)) == "ZeroBundle{1}(2.0)"
         @test repr(DNEBundle{1}(getfield)) == "DNEBundle{1}(getfield)"
+
+        @test repr(ZeroBundle{1}) == "ZeroBundle{1}"
+        @test repr(ZeroBundle{1, Float64}) == "ZeroBundle{1, Float64}"
+
+        @test repr(typeof(DNEBundle{1}(getfield))) == DNEBundle{1, typeof(getfield)}
     end
 end
 

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -1,0 +1,20 @@
+module tagent
+using Diffractor
+using Diffractor: AbstractZeroBundle, ZeroBundle, DNEBundle
+using Test
+
+@testset "AbstractZeroBundle" begin
+    @testset "Hierachy" begin
+        @test ZeroBundle <: AbstractZeroBundle
+        @test DNEBundle <: AbstractZeroBundle
+        @test ZeroBundle{1} <: AbstractZeroBundle{1}
+        @test ZeroBundle{1,typeof(getfield)} <: AbstractZeroBundle{1,typeof(getfield)}
+    end
+
+    @testset "Display" begin
+        @test repr(ZeroBundle{1}(2.0)) == "ZeroBundle{1}(2.0)"
+        @test repr(DNEBundle{1}(getfield)) == "DNEBundle{1}(getfield)"
+    end
+end
+
+end  # module


### PR DESCRIPTION
Closes #102 
I should have done this ages ago.
When digesting IR I often copy pasted it into an editor and made this change via <kbd>ctlr</kbd>+<kbd>f</kbd>. So it's clearly a good idea.


A potentially contentious change is to overload the `show` for the types themselves, but I want nice stacktraces. 
Potentially, we could do this via TruncatedStacktraces.jl?