### PR TITLE
Add fwd rule for Core.ifelse

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -215,6 +215,10 @@ function (::∂☆{N})(f::ZeroBundle{N, typeof(ifelse)}, arg::ATB{N, Bool}, args
     ifelse(arg.primal, args...)
 end
 
+function (::∂☆{N})(f::ZeroBundle{N, typeof(Core.ifelse)}, arg::ATB{N, Bool}, args::ATB{N}...) where {N}
+    Core.ifelse(arg.primal, args...)
+end
+
 struct FwdIterate{N, T<:AbstractTangentBundle{N}}
     f::T
 end


### PR DESCRIPTION
Same as Base.ifelse, but it's a separate generic function, so needs its own rule.