### PR TITLE
Give correct method error

### DIFF
--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -22,7 +22,7 @@ function perform_optic_transform(world::UInt, source::LineNumberNode,
     if mthds === nothing || length(mthds) != 1
         # Core.println("[perform_optic_transform] ", sig, " => ", mthds)
         return generate_lambda_ex(world, source,
-            Core.svec(:ff, :args), Core.svec(), :(throw(MethodError(ff, args))))
+            Core.svec(:ff, :args), Core.svec(), :(throw(MethodError(args[1], args[2:end]))))
     end
     match = only(mthds)::Core.MethodMatch
 

--- a/src/stage1/generated.jl
+++ b/src/stage1/generated.jl
@@ -22,7 +22,7 @@ function perform_optic_transform(world::UInt, source::LineNumberNode,
     if mthds === nothing || length(mthds) != 1
         # Core.println("[perform_optic_transform] ", sig, " => ", mthds)
         return generate_lambda_ex(world, source,
-            Core.svec(:ff, :args), Core.svec(), :(throw(MethodError(args[1], args[2:end]))))
+            Core.svec(:ff, :args), Core.svec(), :(throw(MethodError(args[1], args[2:end], $world))))
     end
     match = only(mthds)::Core.MethodMatch
 


### PR DESCRIPTION
While trying to debug #142 ran into this which was making debugging a big more confusing.

### Before:
```
julia> ∂⃖{3}()(x->"x"+x, 1)
ERROR: MethodError: no method matching (::Diffractor.∂⃖recurse{3})(::typeof(+), ::String, ::Int64)

Closest candidates are:
  (::Diffractor.∂⃖recurse)(::Any...)
   @ Diffractor ~/JuliaEnvs/DAECompiler.jl/dev/Diffractor/src/stage1/generated.jl:404

Stacktrace:
```

### After:
```
julia> ∂⃖{3}()(x->"x"+x, 1)
ERROR: MethodError: no method matching +(::String, ::Int64)

Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:585
  +(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}
   @ Base int.jl:87
  +(::AbstractAlgebra.MatrixElem{T}, ::Union{AbstractFloat, Integer, Rational}) where T<:Union{AbstractAlgebra.NCRingElem, AbstractAlgebra.RingElement}
   @ AbstractAlgebra ~/.julia/packages/AbstractAlgebra/e7I3j/src/Matrix.jl:790
  ...

Stacktrace:
```

This is what the error is actually about.
The problem is we couldn't find a `Method` to extract the IR from