### PR TITLE
Fix getindex on CompositeBundle of a struct

### DIFF
--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -296,11 +296,8 @@ CompositeBundle{N, B}(tup::T) where {N, B, T} = CompositeBundle{N, B, T}(tup)
 
 function Base.getindex(tb::CompositeBundle{N, B} where N, tti::TaylorTangentIndex) where {B}
     B <: SArray && error()
-    Tangent{B}(map(tb.tup) do el
-        el[tti]
-    end...)
+    return partial(tb, tti.i)
 end
-
 
 primal(b::CompositeBundle{N, <:Tuple} where N) = map(primal, b.tup)
 function primal(b::CompositeBundle{N, T} where N) where T<:CompositeBundle

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -1,6 +1,8 @@
 module tagent
 using Diffractor
 using Diffractor: AbstractZeroBundle, ZeroBundle, DNEBundle
+using Diffractor: TaylorBundle, TaylorTangentIndex, CompositeBundle
+using ChainRulesCore
 using Test
 
 @testset "AbstractZeroBundle" begin
@@ -22,6 +24,24 @@ using Test
 
         @test repr(typeof(DNEBundle{1}(getfield))) == "DNEBundle{1, typeof(getfield)}"
     end
+end
+
+@testset "AD through constructor" begin
+    #https://github.com/JuliaDiff/Diffractor.jl/issues/152
+    # hits `getindex(::CompositeBundle{Foo152}, ::TaylorTangentIndex)`
+    struct Foo152
+        x::Float64
+    end
+
+    # Unit Test
+    cb = CompositeBundle{1, Foo152}((TaylorBundle{1, Float64}(23.5, (1.0,)),))
+    tti = TaylorTangentIndex(1,)
+    @test cb[tti] == Tangent{Foo152}(; x=1.0)
+
+    # Integration  Test
+    var"'" = Diffractor.PrimeDerivativeFwd
+    f(x) = Foo152(x)
+    @test f'(23.5) == Tangent{Foo152}(; x=1.0)
 end
 
 end  # module


### PR DESCRIPTION
Closes #152 
It is still constructed "wrong" but we fix it in the `getindex`
Not sure if we should have `getindex(::CompositeBundle, ::TaylorTangentIndex)` calling `partial(::CompositeBundle, ::Int)`
(this PR)
or the other way around.
Which is more canonical?

We can always change later.
