### PR TITLE
fix show `Type{<:AbstractZeroBundle}`

### DIFF
--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -262,7 +262,7 @@ wrapper_name(::Type{<:AbstractZeroBundle}) = "AbstractZeroBundle"
 function Base.show(io::IO, T::Type{<:AbstractZeroBundle{N, B}}) where {N,B}
     print(io, wrapper_name(T))
     print(io, @isdefined(N) ? "{$N, " : "{N, ")
-    show(io, B)
+    @isdefined(B) ? show(io, B) : print(io, "B")
     print(io, "}")
 end
 


### PR DESCRIPTION
We arguably should delete this method for all the reasons that you never are supposed to define these, but if we are defining it, we should at least define it right.