### PR TITLE
Don't inline accesses to nonconst globals

### DIFF
--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -254,6 +254,11 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             # TODO: Should we remember whether the callbacks wanted the arg?
             return transform!(ir, arg, order)
         elseif isa(arg, GlobalRef)
+            if !isconst(arg)
+                # Non-const GlabalRefs need to need to be accessed as seperate statements
+                arg = insert_node!(ir, ssa, NewInstruction(arg, Any))
+            end
+
             return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg), Any))
         elseif isa(arg, QuoteNode)
             return ZeroBundle{order}(arg.value)


### PR DESCRIPTION
This fixes a bug that @Keno  identified.

Without this fix, the attached test case errors with:

```
Unbound GlobalRef not allowed in value position
nonconst globals in forward_diff_no_inf!: Error During Test at REPL[4]:1
  Got exception outside of a @test
```

There is nothing complex here, the fix is exactly as Keno described.
So I will probably just merge this as soon as CI passes