### PR TITLE
Don't insert truncation within phi blocks

### DIFF
--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -240,10 +240,12 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             if argorder != order
                 @assert order < argorder
                 return get!(truncation_map, arg=>order) do
+                    # identify where to insert. Must be after phi blocks
+                    pos = SSAValue(find_end_of_phi_block(ir, arg.id))
                     if order == 0
-                        insert_node!(ir, arg, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
                     else
-                        insert_node!(ir, arg, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
                     end
                 end
             end

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -74,31 +74,19 @@ A phi-block is a run on PhiNodes or nothings that must be the first statements w
 
 If `start_search_idx` is not within a phi block to begin with, then just returns `start_search_idx`
 """
-function find_end_of_phi_block(ir, start_search_idx)
+function find_end_of_phi_block(ir, start_search_idx::Int)
     # Short-cut for early exit:
     stmt = ir.stmts[start_search_idx][:inst]
     stmt !== nothing && !isa(stmt, PhiNode) && return start_search_idx
 
     # Actually going to have to go digging throught the IR to out if were are in a phi block
     # TODO: this is not so efficient. maybe preconstruct CFG then use block_for_inst?
-    start_bb=0
-    found_arg = false
-    end_idx = start_search_idx + 1  # This goes one over, but we will substract one at the end
-    for (bb, idx) in bbidxiter(ir)
-        if !found_arg
-            if idx==start_search_idx
-                start_bb = bb
-                found_arg = true
-            end
-        else # found it
-            end_idx = idx  # This goes one over, but we will substract one at the end
-            # hit end of block, so saft to insert
-            bb !== start_bb && break
-            stmt = ir.stmts[idx][:inst]
-            # No longer in a phi block, so safe to insert
-            stmt !== nothing && !isa(stmt, PhiNode) && break
-        end
+    bb=CC.block_for_inst(ir.cfg, start_search_idx)
+    end_search_idx=ir.cfg.blocks[bb].stmts[end]
+    for idx in (start_search_idx+1):(end_search_idx-1)
+        stmt = ir.stmts[idx+1][:inst]
+        # next statment is no longer in a phi block, so safe to insert
+        stmt !== nothing && !isa(stmt, PhiNode) && return idx
     end
-    end_idx-=1
-    return end_idx
+    return end_search_idx
 end

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -83,7 +83,7 @@ function find_end_of_phi_block(ir, start_search_idx::Int)
     # TODO: this is not so efficient. maybe preconstruct CFG then use block_for_inst?
     bb=CC.block_for_inst(ir.cfg, start_search_idx)
     end_search_idx=ir.cfg.blocks[bb].stmts[end]
-    for idx in (start_search_idx+1):(end_search_idx-1)
+    for idx in (start_search_idx):(end_search_idx-1)
         stmt = ir.stmts[idx+1][:inst]
         # next statment is no longer in a phi block, so safe to insert
         stmt !== nothing && !isa(stmt, PhiNode) && return idx

--- a/test/stage2_fwd.jl
+++ b/test/stage2_fwd.jl
@@ -83,13 +83,11 @@ module forward_diff_no_inf  # todo: move this to a seperate file
         function phi_run(x::Float64)
             a = 2.0
             b = 2.0
-            c = 0.0
             if (@noinline rand()) < 0  # this branch will never actually be taken
                 a = -100.0
                 b = 200.0
-                c = 300.0
             end
-            return x - a + b + c
+            return x - a + b
         end
     
         input_ir = first(only(Base.code_ircode(phi_run, Tuple{Float64})))
@@ -99,7 +97,6 @@ module forward_diff_no_inf  # todo: move this to a seperate file
         for idx in 1:length(ir.stmts)
             if ir.stmts[idx][:inst] isa Core.PhiNode
                 push!(diff_ssa, Core.SSAValue(idx))
-                break
             end
         end
     

--- a/test/stage2_fwd.jl
+++ b/test/stage2_fwd.jl
@@ -43,18 +43,22 @@ module stage2_fwd
         g(x) = Diffractor.∂☆{1}()(Diffractor.ZeroBundle{1}(f), Diffractor.TaylorBundle{1}(x, (1.0,)))
         Diffractor.∂☆{1}()(Diffractor.ZeroBundle{1}(g), Diffractor.TaylorBundle{1}(10f0, (1.0,)))
     end
+end
 
+
+module forward_diff_no_inf  # todo: move this to a seperate file
+    using Diffractor, Test
+    # this is needed as transform! is *always* called on Arguments regardless of what visit_custom says
+    identity_transform!(ir, ssa::Core.SSAValue, order) = ir[ssa]
+    function identity_transform!(ir, arg::Core.Argument, order)
+        return Core.Compiler.insert_node!(ir, Core.SSAValue(1), Core.Compiler.NewInstruction(Expr(:call, Diffractor.ZeroBundle{1}, arg), Any))
+    end
+    
     @testset "Constructors in forward_diff_no_inf!" begin
         struct Bar148
             v
         end
         foo_148(x) = Bar148(x)
-
-        # this is needed as transform! is *always* called on Arguments regardless of what visit_custom says
-        identity_transform!(ir, ssa::Core.SSAValue, order) = ir[ssa]
-        function identity_transform!(ir, arg::Core.Argument, order)
-            return Core.Compiler.insert_node!(ir, Core.SSAValue(1), Core.Compiler.NewInstruction(Expr(:call, Diffractor.ZeroBundle{1}, arg), Any))
-        end
 
         ir = first(only(Base.code_ircode(foo_148, Tuple{Float64})))
         Diffractor.forward_diff_no_inf!(ir, [Core.SSAValue(1) => 1]; transform! = identity_transform!)
@@ -67,12 +71,6 @@ module stage2_fwd
         @eval global _coeff::Float64=24.5
         plus_a_global(x) = x + _coeff
 
-        # this is needed as transform! is *always* called on Arguments regardless of what visit_custom says
-        identity_transform!(ir, ssa::Core.SSAValue, order) = ir[ssa]
-        function identity_transform!(ir, arg::Core.Argument, order)
-            return Core.Compiler.insert_node!(ir, Core.SSAValue(1), Core.Compiler.NewInstruction(Expr(:call, Diffractor.ZeroBundle{1}, arg), Any))
-        end
-
         ir = first(only(Base.code_ircode(plus_a_global, Tuple{Float64})))
         Diffractor.forward_diff_no_inf!(ir, [Core.SSAValue(1) => 1]; transform! = identity_transform!)
         ir2 = Core.Compiler.compact!(ir)
@@ -80,4 +78,34 @@ module stage2_fwd
         f = Core.OpaqueClosure(ir2; do_compile=false)
         @test f(3.5) == 28.0
     end
+
+    @testset "runs of phi nodes" begin
+        function phi_run(x::Float64)
+            a = 2.0
+            b = 2.0
+            if (@noinline rand()) < 0  # this branch will never actually be taken
+                a = -1.0
+                b = 2.0
+            end
+            return x - a + b
+        end
+    
+        input_ir = first(only(Base.code_ircode(phi_run, Tuple{Float64})))
+        ir = copy(input_ir)
+        #Workout where to diff to trigger error
+        diff_ssa = Core.SSAValue[]
+        for idx in 1:length(ir.stmts)
+            if ir.stmts[idx][:inst] isa Core.PhiNode
+                push!(diff_ssa, Core.SSAValue(idx))
+            end
+        end
+        @assert length(diff_ssa) == 2
+        @assert diff_ssa[2].id - diff_ssa[1].id == 1
+    
+        Diffractor.forward_diff_no_inf!(ir, diff_ssa .=> 1; transform! = identity_transform!)
+        ir2 = Core.Compiler.compact!(ir)
+        Core.Compiler.verify_ir(ir2)  # This would error if we were not handling nonconst phi nodes correctly (after https://github.com/JuliaLang/julia/pull/50158)
+        f = Core.OpaqueClosure(ir2; do_compile=false)
+        @test f(3.5) == 3.5  # this will segfault if we are not handling phi nodes correctly
+    end    
 end

--- a/test/stage2_fwd.jl
+++ b/test/stage2_fwd.jl
@@ -83,11 +83,13 @@ module forward_diff_no_inf  # todo: move this to a seperate file
         function phi_run(x::Float64)
             a = 2.0
             b = 2.0
+            c = 0.0
             if (@noinline rand()) < 0  # this branch will never actually be taken
-                a = -1.0
-                b = 2.0
+                a = -100.0
+                b = 200.0
+                c = 300.0
             end
-            return x - a + b
+            return x - a + b + c
         end
     
         input_ir = first(only(Base.code_ircode(phi_run, Tuple{Float64})))
@@ -97,10 +99,9 @@ module forward_diff_no_inf  # todo: move this to a seperate file
         for idx in 1:length(ir.stmts)
             if ir.stmts[idx][:inst] isa Core.PhiNode
                 push!(diff_ssa, Core.SSAValue(idx))
+                break
             end
         end
-        @assert length(diff_ssa) == 2
-        @assert diff_ssa[2].id - diff_ssa[1].id == 1
     
         Diffractor.forward_diff_no_inf!(ir, diff_ssa .=> 1; transform! = identity_transform!)
         ir2 = Core.Compiler.compact!(ir)


### PR DESCRIPTION
This goes along with making diffractor follow this rule:
https://github.com/JuliaLang/julia/pull/50158

The hard bit of this PR was writing the test. But now I know kinda how phi-nodes work.
