### PR TITLE
When reinference is required use IR_FLAG_REFINED

### DIFF
--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -248,9 +248,9 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
                     # identify where to insert. Must be after phi blocks
                     pos = SSAValue(find_end_of_phi_block(ir, arg.id))
                     if order == 0
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED), #=attach_after=#true)
                     else
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED), #=attach_after=#true)
                     end
                 end
             end
@@ -262,7 +262,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             return transform!(ir, arg, order, maparg)
         elseif isa(arg, GlobalRef)
             @assert isconst(arg)
-            return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg), Any))
+            return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED))
         elseif isa(arg, QuoteNode)
             return ZeroBundle{order}(arg.value)
         end

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -310,6 +310,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             elseif isa(stmt, SSAValue) || isa(stmt, QuoteNode)
                 inst[:inst] = maparg(stmt, SSAValue(ssa), order)
                 inst[:type] = Any
+                inst[:flag] |= CC.IR_FLAG_REFINED
             elseif isa(stmt, Expr) || isa(stmt, PhiNode) || isa(stmt, PhiCNode) ||
                    isa(stmt, UpsilonNode) || isa(stmt, GotoIfNot) || isa(stmt, Argument)
                 urs = userefs(stmt)
@@ -318,6 +319,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
                 end
                 inst[:inst] = urs[]
                 inst[:type] = Any
+                inst[:flag] |= CC.IR_FLAG_REFINED
             else
                 val = ZeroBundle{order}(inst[:inst])
                 inst[:inst] = val
@@ -337,8 +339,7 @@ function forward_diff!(interp::ADInterpreter, ir::IRCode, src::CodeInfo, mi::Met
 
     for i = 1:length(ir.stmts)
         if ir[SSAValue(i)][:type] == Any
-            # TODO: this flag should actually be being set at the insert site
-            # and we should be filtering on if it is present rather than [:type]=Any
+            @warn "IR_FLAG_REFINED Flag missed on statement" i ir[SSAValue(i)][:inst]
             ir[SSAValue(i)][:flag] |= CC.IR_FLAG_REFINED
         end
     end

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -338,9 +338,12 @@ function forward_diff!(interp::ADInterpreter, ir::IRCode, src::CodeInfo, mi::Met
     ir = compact!(ir)
 
     for i = 1:length(ir.stmts)
-        if ir[SSAValue(i)][:type] == Any
-            @warn "IR_FLAG_REFINED Flag missed on statement" i ir[SSAValue(i)][:inst]
-            ir[SSAValue(i)][:flag] |= CC.IR_FLAG_REFINED
+        inst = ir[SSAValue(i)][:inst]
+        if !isa(inst, ReturnNode) && ir[SSAValue(i)][:type] == Any
+            if iszero(ir[SSAValue(i)][:flag] & CC.IR_FLAG_REFINED)
+                @warn "IR_FLAG_REFINED Flag missed on statement" i inst
+                ir[SSAValue(i)][:flag] |= CC.IR_FLAG_REFINED
+            end
         end
     end
 

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -248,9 +248,9 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
                     # identify where to insert. Must be after phi blocks
                     pos = SSAValue(find_end_of_phi_block(ir, arg.id))
                     if order == 0
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg)), #=attach_after=#true)
                     else
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED), #=attach_after=#true)
+                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}())), #=attach_after=#true)
                     end
                 end
             end
@@ -262,7 +262,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             return transform!(ir, arg, order, maparg)
         elseif isa(arg, GlobalRef)
             @assert isconst(arg)
-            return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED))
+            return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg)))
         elseif isa(arg, QuoteNode)
             return ZeroBundle{order}(arg.value)
         end

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -340,7 +340,7 @@ function forward_diff!(interp::ADInterpreter, ir::IRCode, src::CodeInfo, mi::Met
 
     for i = 1:length(ir.stmts)
         inst = ir[SSAValue(i)][:inst]
-        if !isa(inst, ReturnNode) && ir[SSAValue(i)][:type] == Any
+        if !isa(inst, ReturnNode) && ir[SSAValue(i)][:type] === Any
             if iszero(ir[SSAValue(i)][:flag] & CC.IR_FLAG_REFINED)
                 @warn "IR_FLAG_REFINED Flag missed on statement" i inst
                 ir[SSAValue(i)][:flag] |= CC.IR_FLAG_REFINED

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -300,6 +300,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
                 # TODO: New PiNode that discriminates based on primal?
                 inst[:inst] = maparg(stmt.val, SSAValue(ssa), order)
                 inst[:type] = Any
+                inst[:flag] |= CC.IR_FLAG_REFINED
             elseif isa(stmt, GlobalRef)
                 if !isconst(stmt)
                     # Non-const GlobalRefs need to need to be accessed as seperate statements

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -94,4 +94,5 @@ function replace_call!(ir, idx::SSAValue, new_call)
     ir[idx][:inst] = new_call
     ir[idx][:type] = Any
     ir[idx][:info] = CC.NoCallInfo()
+    ir[idx][:flag] = CC.IR_FLAG_REFINED
 end

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -13,7 +13,7 @@ Base.getindex(ir::IRCode, ssa::SSAValue) =
 Base.copy(ir::IRCode) = Core.Compiler.copy(ir)
 
 function Core.Compiler.NewInstruction(node)
-    Core.Compiler.NewInstruction(node, Any)
+    Core.Compiler.NewInstruction(node, Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED)
 end
 
 function Base.setproperty!(x::Core.Compiler.Instruction, f::Symbol, v)

--- a/src/stage2/forward.jl
+++ b/src/stage2/forward.jl
@@ -60,7 +60,7 @@ function dontuse_nth_order_forward_stage2(tt::Type, order::Int=1)
             if order == 0
                 return
             end
-            nr = insert_node!(ir, ssa, NewInstruction(Expr(:call, getindex, stmt.val, TaylorTangentIndex(order)), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED))
+            nr = insert_node!(ir, ssa, NewInstruction(Expr(:call, getindex, stmt.val, TaylorTangentIndex(order))))
             inst[:inst] = ReturnNode(nr)
         elseif is_known_invoke_or_call(stmt, dont_use_ddt_intrinsic, ir)
             arg = maparg(stmt.args[end], ssa, order+1)

--- a/src/stage2/forward.jl
+++ b/src/stage2/forward.jl
@@ -60,7 +60,7 @@ function dontuse_nth_order_forward_stage2(tt::Type, order::Int=1)
             if order == 0
                 return
             end
-            nr = insert_node!(ir, ssa, NewInstruction(Expr(:call, getindex, stmt.val, TaylorTangentIndex(order)), Any))
+            nr = insert_node!(ir, ssa, NewInstruction(Expr(:call, getindex, stmt.val, TaylorTangentIndex(order)), Any, CC.NoCallInfo(), nothing, CC.IR_FLAG_REFINED))
             inst[:inst] = ReturnNode(nr)
         elseif is_known_invoke_or_call(stmt, dont_use_ddt_intrinsic, ir)
             arg = maparg(stmt.args[end], ssa, order+1)


### PR DESCRIPTION
Follow up to #163 
It's really annoying hunting down all the places this is needed.

Currently haven't touched reverse-mode.

Definately missing some still