### PR TITLE
error for nonliterals

### DIFF
--- a/src/codegen/forward.jl
+++ b/src/codegen/forward.jl
@@ -59,7 +59,7 @@ function fwd_transform!(ci, mi, nargs, N)
             return nothing
         else
             # Fallback case, for literals.
-            # Literals are not Exprs so error for them.
+            # If it is an Expr, then it is not a literal
             if isa(stmt, Expr)
                 error("Unexprected statement encountered. This is a bug in Diffractor. stmt=$stmt")
             end

--- a/src/codegen/forward.jl
+++ b/src/codegen/forward.jl
@@ -58,8 +58,11 @@ function fwd_transform!(ci, mi, nargs, N)
             # version.
             return nothing
         else
-            #TODO put guard here. We really don't want to generate invalid IR
-            # by wrapping something that isn't more or less a literal in a ZeroBundle
+            # Fallback case, for literals.
+            # Literals are not Exprs so error for them.
+            if isa(stmt, Expr)
+                error("Unexprected statement encountered. This is a bug in Diffractor. stmt=$stmt")
+            end
             return Expr(:call, ZeroBundle{N}, stmt)
         end
     end


### PR DESCRIPTION
I believe this is the correct way to detect literals. This has hit us a few times with some unexpected IR statment