### PR TITLE
bipass all Diffractor machinery if there are no partials

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -137,6 +137,18 @@ function (::∂☆shuffle{N})(args::AbstractTangentBundle{N}...) where {N}
     ∂☆p(ZeroBundle{N-1}(frule), #= ZeroBundle{N-1}(DiffractorRuleConfig()), =# tupargs, map(primal, downargs)...)
 end
 
+# Special shortcut case if there is no derivative information at all:
+function (::∂☆internal{N})(f::AbstractZeroBundle{N}, args::AbstractZeroBundle{N}...) where {N}
+    f_v = primal(f)
+    args_v = map(primal, args)
+    return ZeroBundle{N}(f_v(args_v...))
+end
+function (::∂☆internal{1})(f::AbstractZeroBundle{1}, args::AbstractZeroBundle{1}...)
+    f_v = primal(f)
+    args_v = map(primal, args)
+    return ZeroBundle{1}(f_v(args_v...))
+end
+
 function (::∂☆internal{N})(args::AbstractTangentBundle{N}...) where {N}
     r = ∂☆shuffle{N}()(args...)
     if primal(r) === nothing
@@ -146,6 +158,7 @@ function (::∂☆internal{N})(args::AbstractTangentBundle{N}...) where {N}
     end
 end
 (::∂☆{N})(args::AbstractTangentBundle{N}...) where {N} = ∂☆internal{N}()(args...)
+
 
 # Special case rules for performance
 @Base.constprop :aggressive function (::∂☆{N})(f::ATB{N, typeof(getfield)}, x::TangentBundle{N}, s::AbstractTangentBundle{N}) where {N}


### PR DESCRIPTION
> 🎵 I mean, what have you got to lose?
> You know, you come from nothing
> You're going back to nothing
> What have you lost? Nothing
> Nothing will come from nothing, ya know what they say 🎵

Related to the recent work by  @Keno  and @staticfloat.

By the linearity of the derivative operation if the inputs are all zero so is the output.
A case can be made that we actually should be still invoking the `frule`s for this path.
But I am not sure that's a good argument. 
Here the derivative isn't just `iszero` it has been put into the types it is zero and can't ever not be zero.
(This would not for example be the case if it were being mutated)