### PR TITLE
Ensure that `:boundscheck` is properly handled

### DIFF
--- a/src/codegen/forward.jl
+++ b/src/codegen/forward.jl
@@ -54,10 +54,15 @@ function fwd_transform!(ci, mi, nargs, N)
         elseif isexpr(stmt, :foreigncall)
             return Expr(:call, error, "Attempted to AD a foreigncall. Missing rule?")
         elseif isexpr(stmt, :meta) || isexpr(stmt, :inbounds)  || isexpr(stmt, :loopinfo) ||
-               isexpr(stmt, :boundscheck) || isexpr(stmt, :code_coverage_effect)
+               isexpr(stmt, :code_coverage_effect)
             # Can't trust that meta annotations are still valid in the AD'd
             # version.
             return nothing
+        
+        # Always disable `@inbounds`, as we don't actually know if the AD'd
+        # code is truly `@inbounds` or not.
+        elseif isexpr(stmt, :boundscheck)
+            return ZeroBundle{N}(true)
         else
             # Fallback case, for literals.
             # If it is an Expr, then it is not a literal

--- a/src/codegen/reverse.jl
+++ b/src/codegen/reverse.jl
@@ -321,6 +321,8 @@ function diffract_ir!(ir, ci, meth, sparams::Core.SimpleVector, nargs::Int, N::I
                 # We drop gradients for globals and static parameters
             elseif isexpr(stmt, :inbounds)
                 # Nothing to do
+            elseif isexpr(stmt, :boundscheck)
+                # TODO: do something here
             elseif isa(stmt, PhiNode)
                 Δ = do_accum(SSAValue(i))
                 @assert length(ir.cfg.blocks[bb].preds) >= 1

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -69,4 +69,25 @@ end
     @test primal_calls[] == 1
 end
 
+@testset "indexing" begin
+    # Test to make sure that `:boundscheck` and such are properly handled
+    function foo(x)
+        t = (x, x)
+        return t[1] + 1
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo'(1.0) == 1.0
+    end
+
+    # Test that `@inbounds` is ignored by Diffractor
+    function foo_errors(x)
+        t = (x, x)
+        @inbounds return t[3] + 1
+    end
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test_throws BoundsError foo_errors'(1.0) == 1.0
+    end
+end
+
 end


### PR DESCRIPTION
My previous fix was incorrect because `:boundscheck` returns a `Bool`. Let's just force it to `true` for now, which implicitly disables `@inbounds`, which is probably a good idea for us since we haven't gone through the effort of ensuring that all indexing is still valid. Add tests for this so that we catch this breakage faster next time.