### PR TITLE
Use `replace_call!()` to replace `Expr(:call, ...)` values

### DIFF
--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -90,3 +90,9 @@ function find_end_of_phi_block(ir, start_search_idx::Int)
     end
     return end_search_idx
 end
+
+function replace_call!(ir, idx::SSAValue, new_call)
+    ir[idx][:inst] = new_call
+    ir[idx][:type] = Any
+    ir[idx][:info] = CC.NoCallInfo()
+end


### PR DESCRIPTION
This is necessary to prevent the callinfo field from falling out of sync with the call itself, causing future optimization passes (such as inlining) to compute incorrect results.