### PR TITLE
[NFC] Insert truncation/primal just before statement

### DIFF
--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -241,9 +241,9 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
                 @assert order < argorder
                 return get!(truncation_map, arg=>order) do
                     if order == 0
-                        insert_node!(ir, arg, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
+                        insert_node!(ir, ssa, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#false)
                     else
-                        insert_node!(ir, arg, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
+                        insert_node!(ir, ssa, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#false)
                     end
                 end
             end

--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -240,12 +240,10 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             if argorder != order
                 @assert order < argorder
                 return get!(truncation_map, arg=>order) do
-                    # identify where to insert. Must be after phi blocks
-                    pos = SSAValue(find_end_of_phi_block(ir, arg.id))
                     if order == 0
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
+                        insert_node!(ir, arg, NewInstruction(Expr(:call, primal, arg), Any), #=attach_after=#true)
                     else
-                        insert_node!(ir, pos, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
+                        insert_node!(ir, arg, NewInstruction(Expr(:call, truncate, arg, Val{order}()), Any), #=attach_after=#true)
                     end
                 end
             end

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -65,31 +65,6 @@ if isdefined(Core.Compiler, :CallInfo)
     Base.convert(::Type{Core.Compiler.CallInfo}, ::Nothing) = Core.Compiler.NoCallInfo()
 end
 
-
-"""
-    find_end_of_phi_block(ir, start_search_idx)
-
-Finds the last index within the same basic block, on or after the `start_search_idx` which is not within a phi block.
-A phi-block is a run on PhiNodes or nothings that must be the first statements within the basic block.
-
-If `start_search_idx` is not within a phi block to begin with, then just returns `start_search_idx`
-"""
-function find_end_of_phi_block(ir, start_search_idx::Int)
-    # Short-cut for early exit:
-    stmt = ir.stmts[start_search_idx][:inst]
-    stmt !== nothing && !isa(stmt, PhiNode) && return start_search_idx
-
-    # Actually going to have to go digging throught the IR to out if were are in a phi block
-    bb=CC.block_for_inst(ir.cfg, start_search_idx)
-    end_search_idx=ir.cfg.blocks[bb].stmts[end]
-    for idx in (start_search_idx):(end_search_idx-1)
-        stmt = ir.stmts[idx+1][:inst]
-        # next statment is no longer in a phi block, so safe to insert
-        stmt !== nothing && !isa(stmt, PhiNode) && return idx
-    end
-    return end_search_idx
-end
-
 function replace_call!(ir, idx::SSAValue, new_call)
     ir[idx][:inst] = new_call
     ir[idx][:type] = Any

--- a/test/forward_diff_no_inf.jl
+++ b/test/forward_diff_no_inf.jl
@@ -60,7 +60,7 @@ module forward_diff_no_inf
 
         Diffractor.forward_diff_no_inf!(ir, diff_ssa .=> 1; transform! = identity_transform!)
         ir2 = Core.Compiler.compact!(ir)
-        Core.Compiler.verify_ir(ir2)  # This would error if we were not handling nonconst phi nodes correctly (after https://github.com/JuliaLang/julia/pull/50158)
+        Core.Compiler.verify_ir(ir2)  # This would error if we were not handling nonconst phi nodes correctly
         f = Core.OpaqueClosure(ir2; do_compile=false)
         @test f(3.5) == 3.5  # this will segfault if we are not handling phi nodes correctly
     end


### PR DESCRIPTION
NFC = No functional change

This is a more elegant way to handle this than https://github.com/JuliaDiff/Diffractor.jl/pull/162
we just insert the function that is applied to the arguments just before the statement, rather than just after the argument.
thus avoiding need to dodge phi nodes, and making the ir code more readable.
This is also consistent with how we handle `GlobalRef`s

