### PR TITLE
Fix `ZeroBundle` wrapping for GlobalRef PhiNode args

### DIFF
--- a/src/codegen/forward_demand.jl
+++ b/src/codegen/forward_demand.jl
@@ -262,7 +262,7 @@ function forward_diff_no_inf!(ir::IRCode, to_diff::Vector{Pair{SSAValue,Int}};
             return transform!(ir, arg, order, maparg)
         elseif isa(arg, GlobalRef)
             @assert isconst(arg)
-            return insert_node!(ir, ssa, NewInstruction(Expr(:call, ZeroBundle{order}, arg)))
+            return ZeroBundle{order}(getfield(arg.mod, arg.name))
         elseif isa(arg, QuoteNode)
             return ZeroBundle{order}(arg.value)
         end


### PR DESCRIPTION
These are not legal to insert in-place for PhiNodes. Without this change:
```
272 ┄─ %3410  = φ (#270 => bsim4_vamodel.bsim4_module.NaN, #271 => %3409)::Incidence(Float64, )
```
is transformed into
```
272 ┄─ %3341  = (ZeroBundle{1})(bsim4_vamodel.bsim4_module.NaN)::Any
│      %3342  = φ (#270 => %3341, #271 => %3340)::Any
```

We have to reach back into the preceding basic block and insert the bundle there instead. This solution is a bit of a hack, but at least it gets things working for now.