### PR TITLE
Remove Composite Bundle

### DIFF
--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -10,19 +10,7 @@ This is more or less the Diffractor equivelent of ForwardDiff.jl's `Dual` type.
 """
 function bundle end
 bundle(x, dx::ChainRulesCore.AbstractZero) = UniformBundle{1, typeof(x), typeof(dx)}(x, dx)
-bundle(x::Number, dx::Number) = TaylorBundle{1}(x, (dx,))
-bundle(x::AbstractArray{<:Number}, dx::AbstractArray{<:Number}) = TaylorBundle{1}(x, (dx,))
-bundle(x::P, dx::Tangent{P}) where P = _bundle(x, ChainRulesCore.canonicalize(dx))
-
-"helper that assumes tangent is in canonical form"
-function _bundle(x::P, dx::Tangent{P}) where P
-    # SoA to AoS flip (hate this, hate it even more cos we just undo it later when we hit chainrules)
-    the_bundle = ntuple(Val{fieldcount(P)}()) do ii
-        bundle(getfield(x, ii), getproperty(dx, ii))
-    end
-    return CompositeBundle{1, P}(the_bundle)
-end
-
+bundle(x, dx) = TaylorBundle{1}(x, (dx,))
 
 AD.@primitive function pushforward_function(b::DiffractorForwardBackend, f, args...)
     return function pushforward(vs)

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -7,7 +7,9 @@ function Base.push!(cfg::CFG, bb::BasicBlock)
     push!(cfg.index, bb.stmts.start)
 end
 
-Base.getindex(ir::IRCode, ssa::SSAValue) = Core.Compiler.getindex(ir, ssa)
+if VERSION < v"1.11.0-DEV.258"
+    Base.getindex(ir::IRCode, ssa::SSAValue) = Core.Compiler.getindex(ir, ssa)
+end
 
 Base.copy(ir::IRCode) = Core.Compiler.copy(ir)
 

--- a/src/stage1/compiler_utils.jl
+++ b/src/stage1/compiler_utils.jl
@@ -7,9 +7,7 @@ function Base.push!(cfg::CFG, bb::BasicBlock)
     push!(cfg.index, bb.stmts.start)
 end
 
-if VERSION <= v"1.11.0-DEV.116"
-    Base.getindex(ir::IRCode, ssa::SSAValue) = Core.Compiler.getindex(ir, ssa)
-end
+Base.getindex(ir::IRCode, ssa::SSAValue) = Core.Compiler.getindex(ir, ssa)
 
 Base.copy(ir::IRCode) = Core.Compiler.copy(ir)
 

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -55,8 +55,8 @@ function taylor_compatible(a::ATB{N}, b::ATB{N}) where {N}
 end
 
 function taylor_compatible(r::TaylorBundle{N, Tuple{B1,B2}}) where {N, B1,B2}
-    partial(r, 1)[1] = primal(r)[2] || return false
-    return all(1:N-1) do ii
+    partial(r, 1)[1] == primal(r)[2] || return false
+    return all(1:N-1) do i
         partial(r, i+1)[1] == partial(r, i)[2]
     end
 end
@@ -64,7 +64,7 @@ function shuffle_up(r::TaylorBundle{N, Tuple{B1,B2}}) where {N, B1,B2}
     the_primal = primal(r)[1]
     if taylor_compatible(r)
         the_partials = ntuple(N+1) do i
-            if ii <= N
+            if i <= N
                 partial(r, i)[1]  # == `partial(r,i-1)[2]` (except first which is primal(r)[2])
             else  # ii = N+1
                 partial(r, i-1)[2]

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -238,30 +238,26 @@ function (this::∂☆{N})(::ZeroBundle{N, typeof(Core._apply_iterate)}, iterate
     Core._apply_iterate(FwdIterate(iterate), this, (f,), args...)
 end
 
-#==
-#TODO: port this to TaylorTangent over composite structures
-function (this::∂☆{N})(::ZeroBundle{N, typeof(iterate)}, t::CompositeBundle{N, <:Tuple}) where {N}
-    r = iterate(t.tup)
+
+function (this::∂☆{N})(::ZeroBundle{N, typeof(iterate)}, t::TaylorBundle{N, <:Tuple}) where {N}
+    r = iterate(destructure(t))
     r === nothing && return ZeroBundle{N}(nothing)
     ∂vararg{N}()(r[1], ZeroBundle{N}(r[2]))
 end
 
-#TODO: port this to TaylorTangent over composite structures
-function (this::∂☆{N})(::ZeroBundle{N, typeof(iterate)}, t::CompositeBundle{N, <:Tuple}, a::ATB{N}, args::ATB{N}...) where {N}
-    r = iterate(t.tup, primal(a), map(primal, args)...)
+function (this::∂☆{N})(::ZeroBundle{N, typeof(iterate)}, t::TaylorBundle{N, <:Tuple}, a::ATB{N}, args::ATB{N}...) where {N}
+    r = iterate(destructure(t), primal(a), map(primal, args)...)
     r === nothing && return ZeroBundle{N}(nothing)
     ∂vararg{N}()(r[1], ZeroBundle{N}(r[2]))
 end
 
-#TODO: port this to TaylorTangent over composite structures
-function (this::∂☆{N})(::ZeroBundle{N, typeof(Base.indexed_iterate)}, t::CompositeBundle{N, <:Tuple}, i::ATB{N}) where {N}
-    r = Base.indexed_iterate(t.tup, primal(i))
+function (this::∂☆{N})(::ZeroBundle{N, typeof(Base.indexed_iterate)}, t::TaylorBundle{N, <:Tuple}, i::ATB{N}) where {N}
+    r = Base.indexed_iterate(destructure(t), primal(i))
     ∂vararg{N}()(r[1], ZeroBundle{N}(r[2]))
 end
 
-#TODO: port this to TaylorTangent over composite structures
-function (this::∂☆{N})(::ZeroBundle{N, typeof(Base.indexed_iterate)}, t::CompositeBundle{N, <:Tuple}, i::ATB{N}, st1::ATB{N}, st::ATB{N}...) where {N}
-    r = Base.indexed_iterate(t.tup, primal(i), primal(st1), map(primal, st)...)
+function (this::∂☆{N})(::ZeroBundle{N, typeof(Base.indexed_iterate)}, t::TaylorBundle{N, <:Tuple}, i::ATB{N}, st1::ATB{N}, st::ATB{N}...) where {N}
+    r = Base.indexed_iterate(destructure(t), primal(i), primal(st1), map(primal, st)...)
     ∂vararg{N}()(r[1], ZeroBundle{N}(r[2]))
 end
 
@@ -269,11 +265,11 @@ function (this::∂☆{N})(::ZeroBundle{N, typeof(Base.indexed_iterate)}, t::Tan
     ∂vararg{N}()(this(ZeroBundle{N}(getfield), t, i), ZeroBundle{N}(primal(i) + 1))
 end
 
-#TODO: port this to TaylorTangent over composite structures
-function (this::∂☆{N})(::ZeroBundle{N, typeof(getindex)}, t::CompositeBundle{N, <:Tuple}, i::ZeroBundle) where {N}
-    t.tup[primal(i)]
+function (this::∂☆{N})(::ZeroBundle{N, typeof(getindex)}, t::TaylorBundle{N, <:Tuple}, i::ZeroBundle) where {N}
+    field_ind = primal(i)
+    the_partials = ntuple(order_ind->partial(t, order_ind)[field_ind], N)
+    TaylorBundle{N}(primal(t)[field_ind], the_partials)
 end
-==#
 
 function (this::∂☆{N})(::ZeroBundle{N, typeof(typeof)}, x::ATB{N}) where {N}
     DNEBundle{N}(typeof(primal(x)))

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -51,6 +51,18 @@ function shuffle_down(b::CompositeBundle{N, B}) where {N, B}
     z
 end
 
+function shuffle_up(r::TaylorBundle{1, Tuple{B1,B2}}) where {B1,B2}
+    z₀ = primal(r)[1]
+    z₁ = partial(r, 1)[1]
+    z₂ = primal(r)[2]
+    z₁₂ = partial(r, 1)[2]
+    if z₁ == z₂
+        return TaylorBundle{2}(z₀, (z₁, z₁₂))
+    else
+        return ExplicitTangentBundle{2}(z₀, (z₁, z₂, z₁₂))
+    end
+end
+
 function shuffle_up(r::CompositeBundle{1})
     z₀ = primal(r.tup[1])
     z₁ = partial(r.tup[1], 1)
@@ -76,6 +88,7 @@ isswifty(::UniformBundle) = true
 isswifty(b::CompositeBundle) = all(isswifty, b.tup)
 isswifty(::Any) = false
 
+#TODO: port this to TaylorTangent:
 function shuffle_up(r::CompositeBundle{N}) where {N}
     a, b = r.tup
     if isswifty(a) && isswifty(b) && taylor_compatible(a, b)

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -73,8 +73,8 @@ function shuffle_up(r::TaylorBundle{N, Tuple{B1,B2}}) where {N, B1,B2}
         return TaylorBundle{N+1}(the_primal, the_partials)
     else
         #XXX: am dubious of the correctness of this
-        a_partials = ntuple(i->partial(r, ii)[1], N)
-        b_partials = ntuple(i->partial(r, ii)[2], N)
+        a_partials = ntuple(i->partial(r, i)[1], N)
+        b_partials = ntuple(i->partial(r, i)[2], N)
         the_partials = (a_partials..., primal_b, b_partials...)
         return TangentBundle{N+1}(the_primal, the_partials)
     end

--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -194,12 +194,9 @@ struct FwdMap{N, T<:AbstractTangentBundle{N}}
 end
 (f::FwdMap{N})(args::AbstractTangentBundle{N}...) where {N} = ∂☆{N}()(f.f, args...)
 
-#==
-# TODO port this to TaylorBundle over composite structure
-function (::∂☆{N})(::ZeroBundle{N, typeof(map)}, f::ATB{N}, tup::CompositeBundle{N, <:Tuple}) where {N}
-    ∂vararg{N}()(map(FwdMap(f), tup.tup)...)
+function (::∂☆{N})(::ZeroBundle{N, typeof(map)}, f::ATB{N}, tup::TaylorBundle{N, <:Tuple}) where {N}
+    ∂vararg{N}()(map(FwdMap(f), destructure(tup))...)
 end
-==#
 
 function (::∂☆{N})(::ZeroBundle{N, typeof(map)}, f::ATB{N}, args::ATB{N, <:AbstractArray}...) where {N}
     # TODO: This could do an inplace map! to avoid the extra rebundling

--- a/src/stage1/recurse_fwd.jl
+++ b/src/stage1/recurse_fwd.jl
@@ -48,7 +48,7 @@ end
 
 _construct(::Type{B}, args) where B<:Tuple = B(args)
 # Hack for making things that do not have public constructors constructable:
-@generated _construct(B::Type, args) = :($(Expr(:splatnew, :B, :args)))
+@generated _construct(B::Type, args) = Expr(:splatnew, :B, :args)
 
 @generated (::∂☆new{N})(B::Type) where {N} = return :(ZeroBundle{$N}($(Expr(:new, :B))))
 

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -202,7 +202,7 @@ end
 const TaylorBundle{N, B, P} = TangentBundle{N, B, TaylorTangent{P}}
 
 function TaylorBundle{N, B}(primal::B, coeffs) where {N, B}
-    check_taylor_invariants(coeffs, primal, N)
+#    check_taylor_invariants(coeffs, primal, N) # TODO: renable this
     _TangentBundle(Val{N}(), primal, TaylorTangent(coeffs))
 end
 

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -290,33 +290,6 @@ end
 
 Base.getindex(u::UniformBundle, ::TaylorTangentIndex) = u.tangent.val
 
-"""
-    CompositeBundle{N, B, B <: Tuple}
-
-Represents the tagent bundle where the base space is some tuple or struct type.
-Mathematically, this tangent bundle is the product bundle of the individual
-element bundles.
-"""
-struct CompositeBundle{N, B, T<:Tuple{Vararg{AbstractTangentBundle{N}}}} <: AbstractTangentBundle{N, B}
-    tup::T
-end
-CompositeBundle{N, B}(tup::T) where {N, B, T} = CompositeBundle{N, B, T}(tup)
-
-function Base.getindex(tb::CompositeBundle{N, B} where N, tti::TaylorTangentIndex) where {B}
-    B <: SArray && error()
-    return partial(tb, tti.i)
-end
-
-primal(b::CompositeBundle{N, <:Tuple} where N) = map(primal, b.tup)
-function primal(b::CompositeBundle{N, T} where N) where T<:CompositeBundle
-    T(map(primal, b.tup)...)
-end
-@generated primal(b::CompositeBundle{N, B} where N) where {B} =
-    quote
-        x = map(primal, b.tup)
-        $(Expr(:splatnew, B, :x))
-    end
-
 expand_singleton_to_array(asize, a::AbstractZero) = fill(a, asize...)
 expand_singleton_to_array(asize, a::AbstractArray) = a
 

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -228,6 +228,18 @@ function Base.getindex(tb::TaylorBundle, tti::CanonicalTangentIndex)
     tb.tangent.coeffs[count_ones(tti.i)]
 end
 
+"for a TaylorTangent{N, <:Tuple} this breaks it up unto 1 TaylorTangent{N} for each element of the primal tuple"
+function destructure(r::TaylorBundle{N, B}) where {N, B<:Tuple}
+    return ntuple(fieldcount(B)) do field_ii
+        the_primal = primal(r)[field_ii]
+        the_partials = ntuple(N) do  order_ii
+            partial(r, order_ii)[field_ii]
+        end
+        return TaylorBundle{N}(the_primal, the_partials)
+    end
+end
+
+
 function truncate(tt::TaylorTangent, order::Val{N}) where {N}
     TaylorTangent(tt.coeffs[1:N])
 end

--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -202,15 +202,13 @@ end
 const TaylorBundle{N, B, P} = TangentBundle{N, B, TaylorTangent{P}}
 
 function TaylorBundle{N, B}(primal::B, coeffs) where {N, B}
-#    check_taylor_invariants(coeffs, primal, N) # TODO: renable this
+    check_taylor_invariants(coeffs, primal, N)
     _TangentBundle(Val{N}(), primal, TaylorTangent(coeffs))
 end
 
 function check_taylor_invariants(coeffs, primal, N)
     @assert length(coeffs) == N
-    if isa(primal, TangentBundle)
-        @assert isa(coeffs[1], TangentBundle)
-    end
+
 end
 @ChainRulesCore.non_differentiable check_taylor_invariants(coeffs, primal, N)
 

--- a/test/AbstractDifferentiationTests.jl
+++ b/test/AbstractDifferentiationTests.jl
@@ -7,14 +7,14 @@ backend = Diffractor.DiffractorForwardBackend()
 
     @test bundle(1.0, 2.0) isa Diffractor.TaylorBundle{1}
     @test bundle([1.0, 2.0], [2.0, 3.0]) isa Diffractor.TaylorBundle{1}
-    @test bundle(1.5=>2.5, Tangent{Pair{Float64, Float64}}(first=1.0, second=2.0)) isa Diffractor.CompositeBundle{1}
+    @test bundle(1.5=>2.5, Tangent{Pair{Float64, Float64}}(first=1.0, second=2.0)) isa Diffractor.TaylorBundle{1}
     @test bundle(1.1, ChainRulesCore.ZeroTangent()) isa Diffractor.ZeroBundle{1}
-    @test bundle(1.5=>2.5=>3.5, Tangent{Pair{Float64, Pair{Float64, Float64}}}(first=1.0, second=Tangent{Pair{Float64, Float64}}(first=1.0, second=2.0))) isa Diffractor.CompositeBundle{1}
+    @test bundle(1.5=>2.5=>3.5, Tangent{Pair{Float64, Pair{Float64, Float64}}}(first=1.0, second=Tangent{Pair{Float64, Float64}}(first=1.0, second=2.0))) isa Diffractor.TaylorBundle{1}
     
     # noncanonical structural tangent
     b = bundle(1.5=>2.5=>3.5, Tangent{Pair{Float64, Pair{Float64, Float64}}}(second=Tangent{Pair{Float64, Float64}}(second=2.0, first=1.0)))
     t = Diffractor.first_partial(b)
-    @test b isa Diffractor.CompositeBundle{1}
+    @test b isa Diffractor.TaylorBundle{1}
     @test iszero(t.first)
     @test t.second.first == 1.0
     @test t.second.second == 2.0

--- a/test/AbstractDifferentiationTests.jl
+++ b/test/AbstractDifferentiationTests.jl
@@ -29,7 +29,7 @@ end
 
 # standard tests from AbstractDifferentiation.test_utils
 include(joinpath(pathof(AbstractDifferentiation), "..", "..", "test", "test_utils.jl"))
-@testset "ForwardDiffBackend" begin
+@testset "Standard AbstractDifferentiation.test_utils tests" begin
     backends = [
         @inferred(Diffractor.DiffractorForwardBackend())
     ]

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -1,6 +1,6 @@
 module forward_tests
 using Diffractor
-using Diffractor: TaylorBundle
+using Diffractor: TaylorBundle, ZeroBundle
 using ChainRules
 using ChainRulesCore
 using ChainRulesCore: ZeroTangent, NoTangent, frule_via_ad, rrule_via_ad
@@ -10,8 +10,10 @@ using Test
 
 
 # Minimal 2-nd order forward smoke test
-@test Diffractor.∂☆{2}()(Diffractor.ZeroBundle{2}(sin),
-    Diffractor.ExplicitTangentBundle{2}(1.0, (1.0, 1.0, 0.0)))[Diffractor.CanonicalTangentIndex(1)] == sin'(1.0)
+let var"'" = Diffractor.PrimeDerivativeFwd
+    @test Diffractor.∂☆{2}()(ZeroBundle{2}(sin),
+        Diffractor.ExplicitTangentBundle{2}(1.0, (1.0, 1.0, 0.0)))[Diffractor.CanonicalTangentIndex(1)] == sin'(1.0)
+end
 
 # Simple Forward Mode tests
 let var"'" = Diffractor.PrimeDerivativeFwd

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -25,8 +25,7 @@ let var"'" = Diffractor.PrimeDerivativeFwd
     # Integration tests
     @test recursive_sin'(1.0) == cos(1.0)
     @test recursive_sin''(1.0) == -sin(1.0)
-    # Error: ArgumentError: Tangent for the primal Tangent{Tuple{Float64, Float64}, Tuple{Float64, Float64}}
-    # should be backed by a NamedTuple type, not by Tuple{Tangent{Tuple{Float64, Float64}, Tuple{Float64, Float64}}}.
+    
     @test_broken recursive_sin'''(1.0) == -cos(1.0)
     @test_broken recursive_sin''''(1.0) == sin(1.0)
     @test_broken recursive_sin'''''(1.0) == cos(1.0)
@@ -40,6 +39,7 @@ let var"'" = Diffractor.PrimeDerivativeFwd
 end
 
 # Some Basic Mixed Mode tests
+# TODO: unbreak this
 function sin_twice_fwd(x)
     let var"'" = Diffractor.PrimeDerivativeFwd
             sin''(x)
@@ -87,6 +87,48 @@ end
     end
     let var"'" = Diffractor.PrimeDerivativeFwd
         @test_throws BoundsError foo_errors'(1.0) == 1.0
+    end
+end
+
+
+@testset "structs" begin
+    struct IDemo
+        x::Float64
+        y::Float64
+    end
+
+    function foo(a)
+        obj = IDemo(2.0, a)
+        return obj.x * obj.y
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo'(100.0) == 2.0
+        @test foo''(100.0) == 0.0
+    end
+end
+
+@testset "tuples" begin
+    function foo(a)
+        tup = (2.0, a)
+        return first(tup) * tup[2]
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo'(100.0) == 2.0
+        @test foo''(100.0) == 0.0
+    end
+end
+
+@testset "vararg" begin
+    function foo(a)
+        tup = (2.0, a)
+        return *(tup...)
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo'(100.0) == 2.0
+        @test foo''(100.0) == 0.0
     end
 end
 

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -39,7 +39,6 @@ let var"'" = Diffractor.PrimeDerivativeFwd
 end
 
 # Some Basic Mixed Mode tests
-# TODO: unbreak this
 function sin_twice_fwd(x)
     let var"'" = Diffractor.PrimeDerivativeFwd
             sin''(x)

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -1,7 +1,7 @@
 module tagent
 using Diffractor
 using Diffractor: AbstractZeroBundle, ZeroBundle, DNEBundle
-using Diffractor: TaylorBundle, TaylorTangentIndex, CompositeBundle
+using Diffractor: TaylorBundle, TaylorTangentIndex
 using Diffractor: ExplicitTangent, TaylorTangent, truncate
 using ChainRulesCore
 using Test
@@ -28,21 +28,22 @@ using Test
 end
 
 @testset "AD through constructor" begin
-    #https://github.com/JuliaDiff/Diffractor.jl/issues/152
-    # hits `getindex(::CompositeBundle{Foo152}, ::TaylorTangentIndex)`
+    # https://github.com/JuliaDiff/Diffractor.jl/issues/152
+    # Though we have now removed the underlying cause, we keep this as a regression test just in case
     struct Foo152
         x::Float64
     end
 
     # Unit Test
-    cb = CompositeBundle{1, Foo152}((TaylorBundle{1, Float64}(23.5, (1.0,)),))
+    cb = TaylorBundle{1, Foo152}(Foo152(23.5), (Tangent{Foo152}(;x=1.0),))   
     tti = TaylorTangentIndex(1,)
     @test cb[tti] == Tangent{Foo152}(; x=1.0)
 
     # Integration  Test
-    var"'" = Diffractor.PrimeDerivativeFwd
-    f(x) = Foo152(x)
-    @test f'(23.5) == Tangent{Foo152}(; x=1.0)
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        f(x) = Foo152(x)
+        @test f'(23.5) == Tangent{Foo152}(; x=1.0)
+    end
 end
 
 @testset "truncate" begin

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -35,7 +35,7 @@ end
     end
 
     # Unit Test
-    cb = TaylorBundle{1, Foo152}(Foo152(23.5), (Tangent{Foo152}(;x=1.0),))   
+    cb = TaylorBundle{1, Foo152}(Foo152(23.5), (Tangent{Foo152}(;x=1.0),))
     tti = TaylorTangentIndex(1,)
     @test cb[tti] == Tangent{Foo152}(; x=1.0)
 


### PR DESCRIPTION
This is a prerequisite for  #189  as how CompositeBundle works,  causes a problem when it comes to mutation.

Right now `CompositeBundle` stores everything as a tuple of other Bundles, one per field of the primal.
Rather than storing things as a a a primal and a  tangent (or really 1 or more tangents).
This is a problem because when we need to get stuff back seperated into primal and tangent (which we need to do to apply `frules` or to actually get at the derivative result) we need to assemble the Tangent (note the capital T, this is the type that represents an immutable structural tangent)  on the fly.
Which we do here: https://github.com/JuliaDiff/Diffractor.jl/blob/ee8af85b04da82a3292cc071df9059d87d1d00fa/src/stage1/forward.jl#L8-L14
That is all well and good if everything is immuatable, since there is no need to preserve mutation or worry about aliasing if things are immuable.
If on the other hand, things are  mutable, you do need to worry about this things. In particular the `MutableTangent` type must be aliased in the same places its primal is (infact in the PR https://github.com/JuliaDiff/ChainRulesCore.jl/pull/626/ that created that, I always made a note in the docstring), you very much can not break it a part and recreate it on demand.
Ergo, I think CompositeBundle needs to be removed and replaced with something that works like the other tangent types, a pair of primal and tangent values.
Namely `TaylorTangent` in most cases, though in theory it might end up with an `ExplictTangent`

However, actually removing `CompositeBundle` seems a net significant simplification of the code base.
This PR is net  negative in lines of code in `src/` and will get even more negative once I work out which of the remaining const prop aggressive special cases can be deleted.
It also fixes some existing issues and I think will make others easier to fix in the future.