### PR TITLE
Put some guards on types allowed in TaylorTangents

### DIFF
--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -90,9 +90,14 @@ struct ExplicitTangent{P <: Tuple} <: AbstractTangentSpace
     partials::P
 end
 
+
 @eval struct TaylorTangent{C <: Tuple} <: AbstractTangentSpace
     coeffs::C
-    TaylorTangent(coeffs) = $(Expr(:new, :(TaylorTangent{typeof(coeffs)}), :coeffs))
+    function TaylorTangent(coeffs)
+        bad_tangent_type = Union{DataType, Symbol, String, Nothing}  # protect against obvious mistakes
+        any(c->isa(c, bad_tangent_type), coeffs) && throw(DomainError(coeffs, "Nonvector-space partial type"))
+        $(Expr(:new, :(TaylorTangent{typeof(coeffs)}), :coeffs))
+    end
 end
 
 """

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -1,4 +1,4 @@
-module tagent
+module tangent
 using Diffractor
 using Diffractor: AbstractZeroBundle, ZeroBundle, DNEBundle
 using Diffractor: TaylorBundle, TaylorTangentIndex
@@ -52,6 +52,14 @@ end
     et = ExplicitTangent((1.0,2.0,3.0,4.0,5.0,6.0,7.0))
     @test truncate(et, Val(2)) == ExplicitTangent((1.0,2.0,3.0))
     @test truncate(et, Val(1)) == TaylorTangent((1.0,))
+end
+
+
+@testset "Bad Partial Types" begin
+    @test_throws DomainError TaylorBundle{1}(1.5, (ZeroTangent,))   # mistakenly passing a type rather than a value
+    @test_throws DomainError TaylorBundle{1}(1.5, (:a,))
+    @test_throws DomainError TaylorBundle{1}(1.5, (nothing,))
+    @test_throws DomainError TaylorBundle{1}(1.5, ("x",))
 end
 
 end  # module


### PR DESCRIPTION
Not a high priority, and I am not sure if we want to do this.
Hopefully it is zero overhead by I am yet to check.

I found a case in the wild where I had screwed this up, by putting a `ZeroTangent` somewhere that should have gotten a `ZeroTangent()`.
It's possible to screw this up both in Diffractor itself, but also in rule definitions. (though CRTU.jl will protect against the later)
It is nice to error as close to the creation of the bad type as possible to help work out what is triggering it