### PR TITLE
handle Expr(:isdefined,) in forwards mode

### DIFF
--- a/test/forward.jl
+++ b/test/forward.jl
@@ -147,6 +147,19 @@ end
     end
 end
 
+@testset "isdefined" begin
+    function foo_isdefined(x)
+        if (@noinline rand()) < 2
+            a=1  # always happens
+        end
+
+        2*@isdefined(a)*x + @isdefined(_thing_that_is_not_defined)
+    end
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo_isdefined'(100.0) == 2.0
+    end
+end
+
 
 @testset "taylor_compatible" begin
     taylor_compatible = Diffractor.taylor_compatible


### PR DESCRIPTION
this was found when doing a nasty nested AD thing.
I do think its nice that https://github.com/JuliaDiff/Diffractor.jl/pull/167 is paying off and making these easy to find and fix