### PR TITLE
Handle tuples with types in them

### DIFF
--- a/src/stage1/recurse_fwd.jl
+++ b/src/stage1/recurse_fwd.jl
@@ -24,7 +24,8 @@ function (::∂☆new{1})(B::Type, xs::AbstractTangentBundle{1}...)
         tangent_nt = NamedTuple{names}(tangent_tup)
         Tangent{B, typeof(tangent_nt)}(tangent_nt)
     end
-    return TaylorBundle{1, B}(the_primal, (the_partial,))
+    B2 = typeof(the_primal)  # HACK: if the_primal actually has types in it then we want to make sure we get DataType not Type(...)
+    return TaylorBundle{1, B2}(the_primal, (the_partial,))
 end
 
 function (::∂☆new{N})(B::Type, xs::AbstractTangentBundle{N}...) where {N}

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -148,6 +148,18 @@ end
 end
 
 
+@testset "types in tuples" begin
+    function foo(a)
+        tup = (a, 2a, Int)
+        return tup[2]
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @test foo'(100.0) == 2.0
+    end
+end
+
+
 @testset "taylor_compatible" begin
     taylor_compatible = Diffractor.taylor_compatible
 


### PR DESCRIPTION
Diffractor was having a bit of a sad because `(Int,)` has type `Tuple{DataType}`
but the primal `B`  has type `Tuple{Type{Int}}`,
and while they are logically the same apparently dispatch does not like that.

The solution right now in this PR is to throw away that extra info we have about `B` and normalize it to just `Typle{DataType}`.
idk if it is best, I am open to other ideas.