### PR TITLE
renable configured frules

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -106,7 +106,7 @@ function shuffle_base(r)
 end
 
 function (::∂☆internal{1})(args::AbstractTangentBundle{1}...)
-    r = frule(#=DiffractorRuleConfig(),=# map(first_partial, args), map(primal, args)...)
+    r = frule(DiffractorRuleConfig(), map(first_partial, args), map(primal, args)...)
     if r === nothing
         return ∂☆recurse{1}()(args...)
     else

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -184,4 +184,22 @@ end
     )
 end
 
+
+@testset "configured frule" begin
+    my_func(x) = sin(x)
+    frule_hits = 0
+    function ChainRulesCore.frule(config::RuleConfig{>:HasForwardsMode}, (_, dx), ::typeof(my_func), x)
+        res=my_func(x)
+        _, der_fwd = ChainRulesCore.frule_via_ad(config, (ChainRulesCore.NoTangent(), dx), sin, x)
+        frule_hits +=1
+        return res, der_fwd
+    end
+
+    let var"'" = Diffractor.PrimeDerivativeFwd
+        @assert frule_hits == 0
+        @test my_func'(1.0) == cos(1.0)
+        @test frule_hits == 1
+    end
+end
+
 end  # module


### PR DESCRIPTION
Resolves #222 
I did a quick test and this didn't seem to break inference.
So I think this is fine.
I don't see reasons it shouldn't work.
But I also do not know why it was disabled in the first place.

at some point in future I think will want to AD through root-finding.
and Roots.jl uses a configured `frule` for that.