### PR TITLE
stop overloading `show` on `Type`s

### DIFF
--- a/src/tangent.jl
+++ b/src/tangent.jl
@@ -304,6 +304,8 @@ wrapper_name(::Type{<:ZeroBundle}) = "ZeroBundle"
 wrapper_name(::Type{<:DNEBundle}) = "DNEBundle"
 wrapper_name(::Type{<:AbstractZeroBundle}) = "AbstractZeroBundle"
 
+#=
+# These methods cause too many invalidations to be feasible
 function Base.show(io::IO, T::Type{<:AbstractZeroBundle{N, B}}) where {N,B}
     print(io, wrapper_name(T))
     print(io, @isdefined(N) ? "{$N, " : "{N, ")
@@ -315,6 +317,7 @@ function Base.show(io::IO, T::Type{<:AbstractZeroBundle{N}}) where {N}
     print(io, wrapper_name(T))
     @isdefined(N) && print(io, "{$N}")
 end
+=#
 
 function Base.show(io::IO, t::AbstractZeroBundle{N}) where N
     print(io, wrapper_name(typeof(t)))

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -16,6 +16,8 @@ using Test
 
     @testset "Display" begin
         @test repr(ZeroBundle{1}(2.0)) == "ZeroBundle{1}(2.0)"
+        #=
+        Overloading of Type printing is disabled for now
         @test repr(DNEBundle{1}(getfield)) == "DNEBundle{1}(getfield)"
 
         @test repr(ZeroBundle{1}) == "ZeroBundle{1}"
@@ -24,6 +26,7 @@ using Test
         @test repr((ZeroBundle{N, Float64} where N).body) == "ZeroBundle{N, Float64}"
 
         @test repr(typeof(DNEBundle{1}(getfield))) == "DNEBundle{1, typeof(getfield)}"
+        =#
     end
 end
 


### PR DESCRIPTION
This causes 10k invalidations and for example caused the loading of a downstream package to go from 13s to 36s (ref https://github.com/EnzymeAD/Enzyme.jl/issues/776).

