### PR TITLE
Allow CI failure on nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +26,11 @@ jobs:
           # - windows-latest
         arch:
           - x64
+        include:
+          - version: 'nightly'
+            allow_failure: true
+          - version: '^1.10.0-0'
+            allow_failure: false
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
I guess with Diffractor tests on nightly are +/- doomed to fail, so they shouldn't get in the way of automated PR checks passing and the badge being green

See https://discourse.julialang.org/t/ignoring-nightly-failure-for-ci-badge/98028/5?u=gdalle