### PR TITLE
Don't use ExplictTangentBundle in frule_via_ad

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -126,7 +126,7 @@ function _frule(::NTuple{<:Any, AbstractZero}, f, primal_args...)
 end
 
 function ChainRulesCore.frule_via_ad(::DiffractorRuleConfig, partials, args...)
-    bundles = map((p,a) -> ExplicitTangentBundle{1}(a, (p,)), partials, args)
+    bundles = map(bundle, partials, args)
     result = ∂☆internal{1}()(bundles...)
     primal(result), first_partial(result)
 end


### PR DESCRIPTION
the surface level change in this PR is rather than using `ExplictTangentBundle` to make our bundles we us the helper function `bundle`.
`bundle` is the almost user facing function that creates the correct type of first order bundle (i.e. dual).
However the functional change of this is that in most cases we will not get `TaylorBundles` rather than `ExplictTangentBundles`.

The use of `ExplictTangentBundle` was introduced in  https://github.com/JuliaDiff/Diffractor.jl/pull/54/
However, since then we have gotten much more confortable thinking of `TaylorBundle{1}` as the normal way to represent a first derivative.
It doesn't hugely matter, since for order 1, they are exactly the same, both mathematically and in memory.
