### PR TITLE
Just call primal on intrinics if all tangents are zero

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -285,6 +285,12 @@ function (this::∂☆{N})(::AbstractZeroBundle{N, typeof(typeof)}, x::ATB{N}) w
     DNEBundle{N}(typeof(primal(x)))
 end
 
+
+function (this::∂☆{N})(f::AbstractZeroBundle{N, Core.IntrinsicFunction}, args::AbstractZeroBundle{N}...) where {N}
+    ff=primal(f)
+    return (zero_bundle{N}())(ff(map(primal, args)...))
+end
+
 function (this::∂☆{N})(f::AbstractZeroBundle{N, Core.IntrinsicFunction}, args::ATB{N}...) where {N}
     ff = primal(f)
     if ff in (Base.not_int, Base.ne_float)


### PR DESCRIPTION
Encountered this in the wild.
I can't however reproduce this in a simple test like
```julia
@testset "zeroed tangents intrinstics" begin
    foo(x,y) = Core.Intrinsics.and_int(x, y)
    z = ∂☆internal{1}()(DNEBundle{1}(foo), DNEBundle{1}(true), DNEBundle{1}(false))
    @test primal(z) == foo(true, false)
    @test first_partial
end
```
Not sure why. Maybe the more general handling of all DNEBundle applies there but for some reason in my real world example? 

An alternative to this is to change our general fallback handling of intrinsics to handle zeros, whether compiletime known or not
```julia
function (this::∂☆{N})(f::AbstractZeroBundle{N, Core.IntrinsicFunction}, args::ATB{N}...) where {N}
    ff = primal(f)
    primal_args = map(primal, args)
    primal_out = ff(primal_args...)
    if all(iszero, primal_args))
        (zero_bundle{N}())(primal_out)
    elseif ff in (Base.not_int, Base.ne_float)
        DNEBundle{N}(primal_out)
    else
        error("Missing rule for intrinsic function $ff")
    end
end
```