### PR TITLE
For Cedar port of handling intrinstics called with zero tangents

### DIFF
--- a/src/stage1/forward.jl
+++ b/src/stage1/forward.jl
@@ -338,6 +338,12 @@ function (this::∂☆{N})(::AbstractZeroBundle{N, typeof(typeof)}, x::ATB{N}) w
     DNEBundle{N}(typeof(primal(x)))
 end
 
+
+function (this::∂☆{N})(f::AbstractZeroBundle{N, Core.IntrinsicFunction}, args::AbstractZeroBundle{N}...) where {N}
+    ff=primal(f)
+    return (zero_bundle{N}())(ff(map(primal, args)...))
+end
+
 function (this::∂☆{N})(f::AbstractZeroBundle{N, Core.IntrinsicFunction}, args::ATB{N}...) where {N}
     ff = primal(f)
     if ff in (Base.not_int, Base.ne_float)


### PR DESCRIPTION
This is just #282  but pointing at the `ox/for_cedar/mutation2` branch.
Discussion should be had over in #282 and this should just be merged if that one requires no changes