### PR TITLE
Adjust to method table changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Diffractor"
 uuid = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Keno Fischer <keno@juliacomputing.com> and contributors"]
 
 [deps]

--- a/src/analysis/forward.jl
+++ b/src/analysis/forward.jl
@@ -100,4 +100,4 @@ end
 
 end
 
-const frule_mt = methods(ChainRulesCore.frule).mt
+const frule_mt = @static VERSION ≥ v"1.13.0-DEV.647" ? nothing : methods(ChainRulesCore.frule).mt

--- a/src/stage2/abstractinterpret.jl
+++ b/src/stage2/abstractinterpret.jl
@@ -7,6 +7,8 @@ using .CC: Const, isconstType, argtypes_to_type, tuple_tfunc, Const,
 using Core: PartialStruct
 using Base.Meta
 
+get_fname(@nospecialize(fT::DataType)) = @static VERSION ≥ v"1.13.0-DEV.647" ? fT.name.singletonname : fT.name.mt.name
+
 function CC.abstract_call_gf_by_type(interp::ADInterpreter, @nospecialize(f),
         arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype), sv::InferenceState, max_methods::Int)
     (;argtypes) = arginfo
@@ -30,7 +32,7 @@ function CC.abstract_call_gf_by_type(interp::ADInterpreter, @nospecialize(f),
                 if rinterp.current_level == 1
                     clos = getfield_tfunc(call.info.rrule_rt, Const(2))
                 else
-                    name = call.info.info.results.matches[1].method.sig.parameters[2].name.mt.name
+                    name = get_fname(call.info.info.results.matches[1].method.sig.parameters[2])
                     clos = PrimClosure(name, rinterp.current_level - 1, 1, getfield_tfunc(call.info.rrule_rt, Const(2)), call.info, nothing)
                 end
             end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/58131 broke a few things, which this PR aims to fix.

Some tests were already failing before this PR (and still are), but at least the intended fixes work so we can get Diffractor to successfully precompile again. @Keno feel free to merge if that looks good to you.